### PR TITLE
Improve Makefile

### DIFF
--- a/XcodeMLtoCXX/test/Makefile
+++ b/XcodeMLtoCXX/test/Makefile
@@ -1,5 +1,6 @@
 .SUFFIXES: .XcodeML .CXX
 .PHONY: test clean
+.PRECIOUS: %.XcodeML
 
 all: test
 


### PR DESCRIPTION
テストが落ちたときに変換元のXcodeMLファイル見られないの不便なので残す(makeがビルド終了後に中間ファイル削除するのを阻止する)ようにしました。