### PR TITLE
Keep arrayTypeProc from std::out_of_range

### DIFF
--- a/XcodeMLtoCXX/src/TypeAnalyzer.cpp
+++ b/XcodeMLtoCXX/src/TypeAnalyzer.cpp
@@ -73,9 +73,8 @@ DEFINE_TA(functionTypeProc) {
 
 DEFINE_TA(arrayTypeProc) {
   XMLString elemName = xmlGetProp(node, BAD_CAST "element_type");
-  auto elemType = map[elemName];
   XMLString name(xmlGetProp(node, BAD_CAST "type"));
-  map[name] = XcodeMl::makeArrayType(name, elemType, 0);
+  map[name] = XcodeMl::makeArrayType(name, elemName, 0);
 }
 
 DEFINE_TA(structTypeProc) {

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -313,6 +313,14 @@ TypeRef makeArrayType(
   );
 }
 
+TypeRef makeArrayType(
+    DataTypeIdent ident,
+    DataTypeIdent elemType,
+    size_t size
+) {
+  return std::make_shared<Array>(ident, elemType, size);
+}
+
 TypeRef makeStructType(
     DataTypeIdent ident,
     std::string name,

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -192,6 +192,12 @@ Array::Array(DataTypeIdent ident, TypeRef elem, size_t s):
   size(std::make_shared<size_t>(s))
 {}
 
+Array::Array(DataTypeIdent ident, DataTypeIdent elem, size_t s):
+  Type(TypeKind::Array, ident),
+  element(elem),
+  size(std::make_shared<size_t>(s))
+{}
+
 std::string Array::makeDeclaration(std::string var, const Environment& env) {
   auto elementType(env[element]);
   if (!elementType) {

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -99,6 +99,7 @@ private:
 class Array : public Type {
 public:
   Array(DataTypeIdent, TypeRef, size_t);
+  Array(DataTypeIdent, DataTypeIdent, size_t);
   std::string makeDeclaration(std::string, const Environment&) override;
   ~Array() override;
   Type* clone() const override;

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -131,6 +131,7 @@ TypeRef makePointerType(DataTypeIdent, TypeRef);
 TypeRef makePointerType(DataTypeIdent, DataTypeIdent);
 TypeRef makeFunctionType(DataTypeIdent, TypeRef, const Function::Params&);
 TypeRef makeArrayType(DataTypeIdent, TypeRef, size_t);
+TypeRef makeArrayType(DataTypeIdent, DataTypeIdent, size_t);
 TypeRef makeStructType(DataTypeIdent, std::string, std::string, SymbolMap &&);
 
 }


### PR DESCRIPTION
<arrayType>要素が、その`elemType`属性の指すデータ型定義要素より先に現れていた場合に異常終了するバグを修正しました。