### PR TITLE
Emit <comment> elements

### DIFF
--- a/CXXtoXML/DeclarationsVisitor.cpp
+++ b/CXXtoXML/DeclarationsVisitor.cpp
@@ -175,6 +175,14 @@ DeclarationsVisitor::PreVisitDecl(Decl *D) {
   // default: use the AST name simply.
   newChild((std::string("Decl:") + D->getDeclKindName()).c_str());    
   setLocation(D->getLocation());
+
+  auto &CXT = mangleContext->getASTContext();
+  auto &SM = CXT.getSourceManager();
+  if (auto RC = CXT.getRawCommentForDeclNoCache(D)) {
+    auto comment = static_cast<std::string>(RC->getRawText(SM));
+    addChild("comment", comment.c_str());
+  } 
+
   if (D->isImplicit()) {
     newProp("is_implicit", "1");
   }


### PR DESCRIPTION
ドキュメンテーションコメントっぽいコメントをcomment要素として出力する。

# 例

## 入力
```
/// simple function declaration
void f() {
  /** declare a variable
   * x is initialized with zero
   */
  int x = 0;

  /// comments for statements are ignored
  if (!x) {
    x++;
  }
}
```

## 出力(抜粋)
```
  <clangAST>
    ...
      <Decl:Function>
        <comment>/// simple function declaration</comment>
        <fullName>f</fullName>
        <NestedNameSpecifierLoc class="NULL"/>
        <DeclarationNameInfo:Identifier>f</DeclarationNameInfo:Identifier>
        <TypeLoc class="FunctionProto">
          <TypeLoc class="Builtin"/>
        </TypeLoc>
        <Stmt:CompoundStmt>
          <Stmt:DeclStmt>
            <Decl:Var>
              <comment>/** declare a variable
   * x is initialized with zero
   */</comment>
              <fullName>x</fullName>
              <NestedNameSpecifierLoc class="NULL"/>
              <TypeLoc class="Builtin"/>
              <Stmt:IntegerLiteral/>
            </Decl:Var>
          </Stmt:DeclStmt>
          <Stmt:IfStmt>
            <Stmt:UnaryOperator>
              <logNotExpr type="bool">
                <Stmt:ImplicitCastExpr>
                  <Stmt:ImplicitCastExpr>
                    <Stmt:DeclRefExpr> ...
```