### PR TITLE
Add child elements to data type definition elements

### DIFF
--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -349,6 +349,19 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
         xmlNewProp(Node, BAD_CAST "return_type",
                    BAD_CAST getTypeName(FT->getReturnType()).c_str());
       }
+      if (auto FTP = dyn_cast<FunctionProtoType>(FT)) {
+        auto paramsNode = xmlNewNode(nullptr, BAD_CAST "params");
+        for (auto& paramT : FTP->getParamTypes()) {
+          auto paramNode = xmlNewNode(nullptr, BAD_CAST "name");
+            // FIXME: Add content (parameter name) to <name> element
+          xmlNewProp(
+              paramNode,
+              BAD_CAST "type",
+              BAD_CAST getTypeName(paramT).c_str());
+          xmlAddChild(paramsNode, paramNode);
+        }
+        xmlAddChild(Node, paramsNode);
+      }
       pushType(T, Node);
     }
     break;

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -313,6 +313,10 @@ makeInheritanceNode(
         typeNode,
         BAD_CAST "ref",
         BAD_CAST TTI.getTypeName(base.getType()).c_str());
+    xmlNewProp(
+        typeNode,
+        BAD_CAST "access",
+        BAD_CAST AccessSpec(base.getAccessSpecifier()).c_str());
     xmlAddChild(inheritanceNode, typeNode);
   }
   return inheritanceNode;

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -419,8 +419,18 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
             idNode,
             BAD_CAST "type",
             BAD_CAST getTypeName(field->getType()).c_str());
-        auto nameNode = xmlNewNode(nullptr, BAD_CAST "name");
-        xmlAddChild(idNode, nameNode);
+        const auto fieldName = field->getIdentifier();
+        if (fieldName) {
+          /* Emit only if the field has name.
+           * Some field does not have name.
+           *  Example: `struct A { int : 0; }; // unnamed bit field`
+           */
+          xmlNewChild(
+              idNode,
+              nullptr,
+              BAD_CAST "name",
+              BAD_CAST fieldName->getName().data());
+        }
         xmlAddChild(symbolsNode, idNode);
       }
     }

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -205,16 +205,16 @@ makeSymbolsNodeForRecordType(
     const RecordType* RT)
 {
   assert(RT);
+  auto symbolsNode = xmlNewNode(nullptr, BAD_CAST "symbols");
   auto RD = RT->getDecl();
   if (!RD) {
-    return nullptr;
+    return symbolsNode; // empty <symbols>
   }
   auto def = RD->getDefinition();
   if (!def) {
-    return nullptr;
+    return symbolsNode; // empty <symbols>
   }
   auto fields = def->fields();
-  auto symbolsNode = xmlNewNode(nullptr, BAD_CAST "symbols");
   for (auto field : fields) {
     auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
     xmlNewProp(

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -259,6 +259,9 @@ makeSymbolsNodeForRecordType(
     const RecordType* RT)
 {
   assert(RT);
+  if (auto CRD = RT->getAsCXXRecordDecl()) {
+    return makeSymbolsNodeForCXXRecordDecl(TTI, CRD);
+  }
   auto symbolsNode = xmlNewNode(nullptr, BAD_CAST "symbols");
   auto RD = RT->getDecl();
   if (!RD) {

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -405,6 +405,26 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
       Node = createNode(T, "unknownRecordType", nullptr);
       pushType(T, Node);
     }
+    auto symbolsNode = xmlNewNode(nullptr, BAD_CAST "symbols");
+    auto RD = llvm::cast<RecordType>(T)->getDecl();
+      // T must be of clang::RecordType so able to be casted
+    if (!RD) {
+      break;
+    }
+    if (auto def = RD->getDefinition()) {
+      auto fields = def->fields();
+      for (auto field : fields) {
+        auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
+        xmlNewProp(
+            idNode,
+            BAD_CAST "type",
+            BAD_CAST getTypeName(field->getType()).c_str());
+        auto nameNode = xmlNewNode(nullptr, BAD_CAST "name");
+        xmlAddChild(idNode, nameNode);
+        xmlAddChild(symbolsNode, idNode);
+      }
+    }
+    xmlAddChild(Node, symbolsNode);
     break;
   }
   case Type::Enum:

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -388,6 +388,7 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
     break;
 
   case Type::Record:
+  {
     rawname = registerRecordType(T);
     if (T->isStructureType()) {
       Node = createNode(T, "structType", nullptr);
@@ -405,7 +406,7 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
       pushType(T, Node);
     }
     break;
-
+  }
   case Type::Enum:
     rawname = registerEnumType(T);
     Node = createNode(T, "enumType", nullptr);

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -317,6 +317,10 @@ makeInheritanceNode(
         typeNode,
         BAD_CAST "access",
         BAD_CAST AccessSpec(base.getAccessSpecifier()).c_str());
+    xmlNewProp(
+        typeNode,
+        BAD_CAST "is_virtual",
+        BAD_CAST (base.isVirtual() ? "1" : "0"));
     xmlAddChild(inheritanceNode, typeNode);
   }
   return inheritanceNode;

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -295,6 +295,29 @@ makeSymbolsNodeForRecordType(
   return symbolsNode;
 }
 
+static xmlNodePtr
+makeInheritanceNode(
+    TypeTableInfo& TTI,
+    const CXXRecordDecl* RD)
+{
+  assert(RD);
+  auto inheritanceNode = xmlNewNode(nullptr, BAD_CAST "inheritedFrom");
+  if (! RD->hasDefinition()) {
+    return inheritanceNode; // empty node
+  }
+  const auto def = RD->getDefinition();
+
+  for (auto&& base : def->bases()) {
+    auto typeNode = xmlNewNode(nullptr, BAD_CAST "typeName");
+    xmlNewProp(
+        typeNode,
+        BAD_CAST "ref",
+        BAD_CAST TTI.getTypeName(base.getType()).c_str());
+    xmlAddChild(inheritanceNode, typeNode);
+  }
+  return inheritanceNode;
+}
+
 void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
   bool isQualified = false;
   xmlNodePtr Node = nullptr;

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -438,11 +438,12 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
     break;
   }
   case Type::Enum:
+  {
     rawname = registerEnumType(T);
     Node = createNode(T, "enumType", nullptr);
     pushType(T, Node);
     break;
-
+  }
   case Type::Elaborated:
   case Type::Attributed:
   case Type::TemplateTypeParm:

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -518,6 +518,10 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
     } else if (T->isClassType()) {
       // XXX: temporary implementation
       Node = createNode(T, "classType", nullptr);
+      const auto RD = T->getAsCXXRecordDecl();
+      xmlAddChild(
+          Node,
+          makeInheritanceNode(*this, RD));
       pushType(T, Node);
     } else {
       // XXX: temporary implementation


### PR DESCRIPTION
#59 のバグによりデータ型定義要素が子要素を持たないようになってしまいました。このPRはTypeTableInfoを修正し、次の要素が子要素を持つようにします。

* functionType
* unionType
* structType
* classType
* enumType