### PR TITLE
Fix CXXtoXML

### DIFF
--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -208,6 +208,37 @@ getTagKindAsString(clang::TagTypeKind ttk) {
 }
 
 static xmlNodePtr
+makeNameNodeForCXXMethodDecl(
+    TypeTableInfo&,
+    const CXXMethodDecl* MD)
+{
+  if (isa<CXXConstructorDecl>(MD)) {
+    auto ctorNode = xmlNewNode(nullptr, BAD_CAST "constructor");
+    xmlNewProp(
+        ctorNode,
+        BAD_CAST "name_kind",
+        BAD_CAST "constructor");
+    return ctorNode;
+  } else if (isa<CXXDestructorDecl>(MD)) {
+    auto dtorNode = xmlNewNode(nullptr, BAD_CAST "destructor");
+    xmlNewProp(
+        dtorNode,
+        BAD_CAST "name_kind",
+        BAD_CAST "destructor");
+    return dtorNode;
+  }
+  const auto ident = MD->getIdentifier();
+  assert(ident);
+  auto nameNode = xmlNewNode(nullptr, BAD_CAST "name");
+  xmlNodeAddContent(nameNode, BAD_CAST ident->getName().data());
+  xmlNewProp(
+      nameNode,
+      BAD_CAST "name_kind",
+      BAD_CAST "name");
+  return nameNode;
+}
+
+static xmlNodePtr
 makeIdNodeForCXXMethodDecl(
     TypeTableInfo& TTI,
     const CXXMethodDecl* method)

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -248,17 +248,8 @@ makeIdNodeForCXXMethodDecl(
       idNode,
       BAD_CAST "type",
       BAD_CAST TTI.getTypeName(method->getType()).c_str());
-  const auto name = method->getIdentifier();
-  assert(name);
-  auto nameNode = xmlNewChild(
-      idNode,
-      nullptr,
-      BAD_CAST "name",
-      BAD_CAST name->getName().data());
-  xmlNewProp(
-      nameNode,
-      BAD_CAST "name_kind",
-      BAD_CAST "name");
+  auto nameNode = makeNameNodeForCXXMethodDecl(TTI, method);
+  xmlAddChild(idNode, nameNode);
   return idNode;
 }
 

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -212,24 +212,22 @@ makeNameNodeForCXXMethodDecl(
     TypeTableInfo&,
     const CXXMethodDecl* MD)
 {
+  auto nameNode = xmlNewNode(nullptr, BAD_CAST "name");
   if (isa<CXXConstructorDecl>(MD)) {
-    auto ctorNode = xmlNewNode(nullptr, BAD_CAST "constructor");
     xmlNewProp(
-        ctorNode,
+        nameNode,
         BAD_CAST "name_kind",
         BAD_CAST "constructor");
-    return ctorNode;
+    return nameNode;
   } else if (isa<CXXDestructorDecl>(MD)) {
-    auto dtorNode = xmlNewNode(nullptr, BAD_CAST "destructor");
     xmlNewProp(
-        dtorNode,
+        nameNode,
         BAD_CAST "name_kind",
         BAD_CAST "destructor");
-    return dtorNode;
+    return nameNode;
   }
   const auto ident = MD->getIdentifier();
   assert(ident);
-  auto nameNode = xmlNewNode(nullptr, BAD_CAST "name");
   xmlNodeAddContent(nameNode, BAD_CAST ident->getName().data());
   xmlNewProp(
       nameNode,

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -392,8 +392,8 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
     return;
   }
 
-  if (mapFromQualTypeToXmlNodePtr.find(T) !=
-      mapFromQualTypeToXmlNodePtr.end()) {
+  if (mapFromQualTypeToName.find(T) !=
+      mapFromQualTypeToName.end()) {
     if (retNode != nullptr) {
       *retNode = mapFromQualTypeToXmlNodePtr[T];
     }


### PR DESCRIPTION
* クラスをTypeTableInfoに登録する際に自分自身を構成要素に含む型を持つメンバー(例: クラス`A`のメンバー関数`void memfun(const A&)`)があると不正終了する問題を修正
* `<constructor>`要素と`<destrutor>`要素に対応