### PR TITLE
Don't create *.xml files first on `make check`

### DIFF
--- a/CXXtoXML/tests/CppTest/Makefile
+++ b/CXXtoXML/tests/CppTest/Makefile
@@ -39,7 +39,7 @@ $(XCODEMLTOCXX):
 %.generated.cpp: %.xcodeml $(XCODEMLTOCXX)
 	$(XCODEMLTOCXX) $< > $@
 
-check: $(CXXTOXML) $(CXXTESTOBJECTS) $(CXXDECOMPTESTOBJECTS)
+check: $(CXXTOXML) $(CXXDECOMPTESTOBJECTS)
 	set -e; \
 	for testobj in $(CXXDECOMPTESTOBJECTS); do  \
 		$(CXX) $(CXXFLAGS) $$testobj; \


### PR DESCRIPTION
Change file generation order in `make check` in CXXtoXML/tests/CppTest/Makefile.