### PR TITLE
Add support for constructor / destructor declarations to CXXtoXML(and XSLT)

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -432,6 +432,24 @@ DeclarationsVisitor::PreVisitNestedNameSpecifierLoc(
   }
   return true;
 }
+
+bool
+DeclarationsVisitor::PreVisitConstructorInitializer(
+    CXXCtorInitializer* CI)
+{
+  if (!CI) {
+    return true;
+  }
+  newChild("clangConstructorInitializer");
+
+  // FIXME: temporary implementation
+
+  if (auto member = CI->getMember()) {
+    newProp("member", member->getNameAsString().c_str());
+  }
+  return true;
+}
+
 ///
 /// Local Variables:
 /// indent-tabs-mode: nil

--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -244,7 +244,7 @@ getNameKind(NamedDecl* ND) {
     return "constructor";
   }
   if (isa<CXXDestructorDecl>(FD)) {
-    return "constructor";
+    return "destructor";
   }
   return "name";
 }

--- a/CXXtoXML/src/DeclarationsVisitor.h
+++ b/CXXtoXML/src/DeclarationsVisitor.h
@@ -15,6 +15,7 @@ public:
     bool PostVisitDecl(clang::Decl *);
     bool PreVisitDeclarationNameInfo(clang::DeclarationNameInfo);
     bool PreVisitNestedNameSpecifierLoc(clang::NestedNameSpecifierLoc);
+    bool PreVisitConstructorInitializer(clang::CXXCtorInitializer *);
 };
 
 #endif /* !DECLARATIONSVISITOR_H */

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -30,7 +30,10 @@
     <xsl:apply-templates />
   </xsl:template>
 
-  <xsl:template match="clangDecl[@class='Function' or @class='CXXMethod']">
+  <xsl:template match="clangDecl[@class='Function'
+      or @class='CXXMethod'
+      or @class='CXXConstructor'
+      or @class='CXXDestructor']">
     <xsl:choose>
       <xsl:when test="clangStmt">
         <functionDefinition>

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -42,6 +42,12 @@
 
           <xsl:apply-templates select="params" />
 
+          <xsl:if test="@class='CXXConstructor'">
+            <constructorInitializerList>
+              <xsl:apply-templates select="clangConstructorInitializer" />
+            </constructorInitializerList>
+          </xsl:if>
+
           <body>
             <xsl:apply-templates select="clangStmt" />
           </body>
@@ -54,6 +60,13 @@
         </functionDecl>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="clangConstructorInitializer">
+    <constructorInitializer>
+      <xsl:copy-of select="@*" /> <!-- including @member -->
+      <xsl:apply-templates select="*" />
+    </constructorInitializer>
   </xsl:template>
 
   <xsl:template match="clangDecl[@class='Var']">

--- a/CXXtoXML/src/XSLTs/add_symbols_elem.xsl
+++ b/CXXtoXML/src/XSLTs/add_symbols_elem.xsl
@@ -34,7 +34,10 @@
     </clangStmt>
   </xsl:template>
 
-  <xsl:template match="clangDecl[@class='Function' or @class='CXXMethod']">
+  <xsl:template match="clangDecl[@class='Function'
+      or @class='CXXMethod'
+      or @class='CXXConstructor'
+      or @class='CXXDestructor']">
     <clangDecl>
       <xsl:apply-templates select="@*" />
 

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -543,13 +543,12 @@ DEFINE_CB(ctorInitListProc) {
   if (inits.empty()) {
     return makeVoidNode();
   }
-  auto decl = makeTokenNode(":");
+  auto decl = makeVoidNode();
   bool alreadyPrinted = false;
   for (auto init : inits) {
-    if (alreadyPrinted) {
-      decl = decl + makeTokenNode(",");
-    }
-    decl = decl + w.walk(init, src);
+    decl = decl
+      + makeTokenNode(alreadyPrinted ? ":" : ",")
+      + w.walk(init, src);
   }
   return decl;
 }

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -538,6 +538,22 @@ DEFINE_CB(varDeclProc) {
   return acc + makeTokenNode(";");
 }
 
+DEFINE_CB(ctorInitListProc) {
+  auto inits = findNodes(node, "constructorInitializer", src.ctxt);
+  if (inits.empty()) {
+    return makeVoidNode();
+  }
+  auto decl = makeTokenNode(":");
+  bool alreadyPrinted = false;
+  for (auto init : inits) {
+    if (alreadyPrinted) {
+      decl = decl + makeTokenNode(",");
+    }
+    decl = decl + w.walk(init, src);
+  }
+  return decl;
+}
+
 DEFINE_CB(ctorInitProc) {
   const auto member = getProp(node, "member");
   auto expr = findFirst(node, "*[1]", src.ctxt);

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -547,7 +547,7 @@ DEFINE_CB(ctorInitListProc) {
   bool alreadyPrinted = false;
   for (auto init : inits) {
     decl = decl
-      + makeTokenNode(alreadyPrinted ? ":" : ",")
+      + makeTokenNode(alreadyPrinted ? "," : ":")
       + w.walk(init, src);
   }
   return decl;

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -538,6 +538,16 @@ DEFINE_CB(varDeclProc) {
   return acc + makeTokenNode(";");
 }
 
+DEFINE_CB(ctorInitProc) {
+  const auto member = getProp(node, "member");
+  auto expr = findFirst(node, "*[1]", src.ctxt);
+  assert(expr);
+  return makeTokenNode(member) +
+    makeTokenNode("(") +
+    w.walk(expr, src) +
+    makeTokenNode(")");
+}
+
 const CodeBuilder CXXBuilder(
 "CodeBuilder",
 makeInnerNode,


### PR DESCRIPTION
* 正変換のバグ修正(f27191e)
* CXXtoXMLがclangConstructorInitializer要素を出力するようにした
* メンバー関数に対して適用しているXSLT templateをコンストラクター・デストラクターにも適用した
* 逆変換でコンストラクターに対応するための準備をした