### PR TITLE
Don't emit return type when parsing constructor / destructor definition

### DIFF
--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -360,7 +360,8 @@ DEFINE_CB(emitClassDefinition) {
     makeNewLineNode();
 }
 
-DEFINE_CB(functionDefinitionProc) {
+static XcodeMl::CodeFragment
+makeFunctionDeclHead(xmlNodePtr node, const SourceInfo& src) {
   xmlNodePtr nameElem = findFirst(
       node,
       "name|operator|constructor|destructor",
@@ -373,13 +374,22 @@ DEFINE_CB(functionDefinitionProc) {
 
   const auto dtident = getProp(node, "type");
   const auto T = src.typeTable[dtident];
-  auto fnType = llvm::cast<XcodeMl::Function>(
-      T.get());
+  const auto fnType = llvm::cast<XcodeMl::Function>(T.get());
+  return
+    (kind == "constructor" || kind == "destructor") ?
+      fnType->makeDeclarationWithoutReturnType(
+          nameNode,
+          getParams(node, src),
+          src.typeTable)
+    : fnType->makeDeclaration(
+          nameNode,
+          getParams(node, src),
+          src.typeTable);
+}
+
+DEFINE_CB(functionDefinitionProc) {
   auto acc =
-    fnType->makeDeclaration(
-        nameNode,
-        getParams(node, src),
-        src.typeTable);
+    makeFunctionDeclHead(node, src);
 
   acc = acc + makeTokenNode( "{" ) + makeNewLineNode();
   acc = acc + makeInnerNode(w.walkChildren(node, src));

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -247,19 +247,13 @@ Function::makeDeclarationWithoutReturnType(
     const Environment& env)
 {
   assert(isParamListEmpty() || args.size() == params.size());
-  if (!env.exists(returnValue)) {
-    return makeTokenNode("INCOMPLETE_TYPE *") + var;
-  }
   auto decl = var + makeTokenNode("(");
   bool alreadyPrinted = false;
   for (int i = 0, len = args.size(); i < len; ++i) {
-    if (!env.exists(std::get<0>(params[i]))) {
-      return makeTokenNode( "INCOMPLETE_TYPE *" ) + var;
-    }
     if (alreadyPrinted) {
       decl = decl + makeTokenNode(",");
     }
-    auto paramType = env[std::get<0>(params[i])];
+    auto paramType = env.at(std::get<0>(params[i]));
     decl = decl + makeDecl(paramType, args[i], env);
     alreadyPrinted = true;
   }

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -262,6 +262,19 @@ Function::makeDeclarationWithoutReturnType(
 }
 
 CodeFragment
+Function::makeDeclarationWithoutReturnType(
+    CodeFragment var,
+    const Environment& env)
+{
+  std::vector<CodeFragment> vec;
+  for (auto param : params) {
+    auto paramName(std::get<1>(param));
+    vec.push_back(paramName);
+  }
+  return makeDeclarationWithoutReturnType(var, vec, env);
+}
+
+CodeFragment
 Function::makeDeclaration(
     CodeFragment var,
     const std::vector<CodeFragment>& args,

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -240,7 +240,8 @@ Function::Function(DataTypeIdent ident, TypeRef r, const std::vector<std::tuple<
   params(p)
 {}
 
-CodeFragment Function::makeDeclaration(
+CodeFragment
+Function::makeDeclarationWithoutReturnType(
     CodeFragment var,
     const std::vector<CodeFragment>& args,
     const Environment& env)
@@ -249,7 +250,6 @@ CodeFragment Function::makeDeclaration(
   if (!env.exists(returnValue)) {
     return makeTokenNode("INCOMPLETE_TYPE *") + var;
   }
-  auto returnType = env[returnValue];
   auto decl = var + makeTokenNode("(");
   bool alreadyPrinted = false;
   for (int i = 0, len = args.size(); i < len; ++i) {
@@ -264,10 +264,18 @@ CodeFragment Function::makeDeclaration(
     alreadyPrinted = true;
   }
   decl = decl + makeTokenNode(")");
-  return
-    returnType ?
-        makeDecl(returnType, decl, env)
-      : decl;
+  return decl;
+}
+
+CodeFragment
+Function::makeDeclaration(
+    CodeFragment var,
+    const std::vector<CodeFragment>& args,
+    const Environment& env)
+{
+  auto returnType = env.at(returnValue);
+  auto decl = makeDeclarationWithoutReturnType(var, args, env);
+  return makeDecl(returnType, decl, env);
 }
 
 CodeFragment Function::makeDeclaration(CodeFragment var, const Environment& env) {

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -125,6 +125,8 @@ public:
   using Params = std::vector<std::tuple<DataTypeIdent, CodeFragment>>;
   Function(DataTypeIdent, TypeRef, const std::vector<DataTypeIdent>&);
   Function(DataTypeIdent, TypeRef, const Params&);
+  CodeFragment makeDeclarationWithoutReturnType(
+      CodeFragment, const std::vector<CodeFragment>&, const Environment&);
   CodeFragment makeDeclaration(CodeFragment, const Environment&) override;
   CodeFragment makeDeclaration(CodeFragment, const std::vector<CodeFragment>&, const Environment&);
   ~Function() override;

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -127,6 +127,7 @@ public:
   Function(DataTypeIdent, TypeRef, const Params&);
   CodeFragment makeDeclarationWithoutReturnType(
       CodeFragment, const std::vector<CodeFragment>&, const Environment&);
+  CodeFragment makeDeclarationWithoutReturnType(CodeFragment, const Environment&);
   CodeFragment makeDeclaration(CodeFragment, const Environment&) override;
   CodeFragment makeDeclaration(CodeFragment, const std::vector<CodeFragment>&, const Environment&);
   ~Function() override;


### PR DESCRIPTION
clang::FunctionTypeはコンストラクター・デストラクターの返り値型をvoid型としているため、逆変換の際に不適切な宣言を出力してしまう。例:
```
class A {
void A(int i, int j){
}
};
```

そこで、Function::makeDeclarationWithoutReturnTypeを実装し、逆変換でメンバー関数の定義を出力するときにコンストラクターでもデストラクターでもない場合にのみ返り値型を出力するようにした。

正変換側ではなく逆変換側で対応したのは、ある関数型に対応する関数がコンストラクターまたはデストラクターであるかを、データ型をtypeTableに登録するタイミング(TypeTableInfo::registerType)で判定することが難しいため。

定義を伴わない宣言(例: `class A { A(int i, int j); };`)については未対応。