### PR TITLE
Use ClangStmtHandler in CodeBuilder

### DIFF
--- a/XcodeMLtoCXX/src/AttrProc.h
+++ b/XcodeMLtoCXX/src/AttrProc.h
@@ -10,22 +10,22 @@ public:
   AttrProc(
       const std::string& a,
       std::function<ReturnT(const std::vector<ReturnT>&)> f,
-      std::function<ReturnT()> e,
+      Procedure d,
       std::initializer_list<std::tuple<std::string, Procedure>> m):
     attr(a),
     fold(f),
-    empty(e),
+    defaultProc(d),
     map(m)
   {}
 
   AttrProc(
       const std::string& a,
       std::function<ReturnT(const std::vector<ReturnT>&)> f,
-      std::function<ReturnT()> e,
+      Procedure d,
       std::map<std::string, Procedure>&& m):
     attr(a),
     fold(f),
-    empty(e),
+    defaultProc(d),
     map(m)
   {}
 
@@ -37,7 +37,7 @@ public:
     if (iter != map.end()) {
       return (iter->second)(node, args...);
     }
-    return empty();
+    return defaultProc(node, args...);
   }
 
   std::vector<ReturnT> walkAll(xmlNodePtr node, T... args) const {
@@ -57,7 +57,7 @@ public:
 private:
   std::string attr;
   std::function<ReturnT(const std::vector<ReturnT>&)> fold;
-  std::function<ReturnT()> empty;
+  Procedure defaultProc;
   std::map<std::string, Procedure> map;
 };
 

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -29,6 +29,13 @@ namespace cxxgen = CXXCodeGen;
 
 #define DEFINE_CCH(name) static XcodeMl::CodeFragment name(CCH_ARGS)
 
+using cxxgen::makeInnerNode;
+using cxxgen::makeTokenNode;
+
+DEFINE_CCH(callCodeBuilder) {
+  return makeInnerNode(w.walkChildren(node, src));
+}
+
 DEFINE_CCH(callExprProc) {
   return (w["functionCall"])(w, node, src);
 }
@@ -36,7 +43,7 @@ DEFINE_CCH(callExprProc) {
 const ClangClassHandler ClangStmtHandler(
     "class",
     cxxgen::makeInnerNode,
-    cxxgen::makeVoidNode,
+    callCodeBuilder,
     {
       { "CallExpr", callExprProc },
     });

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -25,17 +25,18 @@ namespace cxxgen = CXXCodeGen;
 
 #define CCH_ARGS xmlNodePtr node __attribute__((unused)), \
                  const CodeBuilder& w __attribute__((unused)), \
-                 SourceInfo& src __attribute__((unused)), \
-                 cxxgen::Stream& ss __attribute__((unused))
+                 SourceInfo& src __attribute__((unused))
 
-#define DEFINE_CCH(name) static void name(CCH_ARGS)
+#define DEFINE_CCH(name) static XcodeMl::CodeFragment name(CCH_ARGS)
 
 DEFINE_CCH(callExprProc) {
-  (w["functionCall"])(w, node, src);
+  return (w["functionCall"])(w, node, src);
 }
 
 const ClangClassHandler ClangStmtHandler(
     "class",
+    cxxgen::makeInnerNode,
+    cxxgen::makeVoidNode,
     {
       { "CallExpr", callExprProc },
     });

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -31,6 +31,7 @@ namespace cxxgen = CXXCodeGen;
 
 using cxxgen::makeInnerNode;
 using cxxgen::makeTokenNode;
+using XcodeMl::CodeFragment;
 
 DEFINE_CCH(callCodeBuilder) {
   return makeInnerNode(w.walkChildren(node, src));
@@ -46,7 +47,13 @@ DEFINE_CCH(CXXTemporaryObjectExprProc) {
   const auto name =
     llvm::cast<XcodeMl::ClassType>(resultT.get())->name();
   assert(name.hasValue());
-  const auto args = w.walkChildren(node, src);
+  auto children = findNodes(node, "*[position() > 1]", src.ctxt);
+    // ignore first child, which represents the result (class) type of
+    // the clang::CXXTemporaryObjectExpr
+  std::vector<CodeFragment> args;
+  for (auto child : children) {
+    args.push_back(w.walk(child, src));
+  }
   return *name +
     makeTokenNode("(") +
     join(",", args) +

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -40,10 +40,24 @@ DEFINE_CCH(callExprProc) {
   return (w["functionCall"])(w, node, src);
 }
 
+DEFINE_CCH(CXXTemporaryObjectExprProc) {
+  const auto resultT = src.typeTable.at(
+      getProp(node, "type"));
+  const auto name =
+    llvm::cast<XcodeMl::ClassType>(resultT.get())->name();
+  assert(name.hasValue());
+  const auto args = w.walkChildren(node, src);
+  return *name +
+    makeTokenNode("(") +
+    join(",", args) +
+    makeTokenNode(")");
+}
+
 const ClangClassHandler ClangStmtHandler(
     "class",
     cxxgen::makeInnerNode,
     callCodeBuilder,
     {
       { "CallExpr", callExprProc },
+      { "CXXTemporaryObjectExpr", CXXTemporaryObjectExprProc },
     });

--- a/XcodeMLtoCXX/src/ClangClassHandler.h
+++ b/XcodeMLtoCXX/src/ClangClassHandler.h
@@ -2,10 +2,9 @@
 #define CLANGCLASSHANDLER_H
 
 using ClangClassHandler = AttrProc<
-  void,
+  XcodeMl::CodeFragment,
   const CodeBuilder&,
-  SourceInfo&,
-  CXXCodeGen::Stream&>;
+  SourceInfo&>;
 
 extern const ClangClassHandler ClangStmtHandler;
 

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -602,12 +602,14 @@ DEFINE_CB(ctorInitProc) {
     makeTokenNode(")");
 }
 
+DEFINE_CB(clangStmtProc) {
+  return ClangStmtHandler.walk(node, w, src);
+}
+
 const CodeBuilder CXXBuilder(
 "CodeBuilder",
 makeInnerNode,
 {
-  //{ "clangStmt", clangStmtProc },
-
   { "typeTable", NullProc },
   { "functionDefinition", functionDefinitionProc },
   { "functionDecl", functionDeclProc },
@@ -675,6 +677,9 @@ makeInnerNode,
   { "returnStatement", returnStatementProc },
   { "varDecl", varDeclProc },
   { "classDecl", emitClassDefinition },
+
+  /* for elements defined by clang */
+  { "clangStmt", clangStmtProc },
 
   /* for CtoXcodeML */
   { "Decl_Record", NullProc },

--- a/XcodeMLtoCXX/src/StringTree.cpp
+++ b/XcodeMLtoCXX/src/StringTree.cpp
@@ -137,6 +137,20 @@ separateByBlankLines(const std::vector<StringTreeRef>& strs) {
   return acc;
 }
 
+StringTreeRef
+join(const std::string& delim, const std::vector<StringTreeRef>& strs) {
+  auto acc = makeVoidNode();
+  bool alreadyPrinted = false;
+  for (auto& str : strs) {
+    if (alreadyPrinted) {
+      acc = acc + makeTokenNode(delim);
+    }
+    acc = acc + str;
+    alreadyPrinted = true;
+  }
+  return acc;
+}
+
 } // namespace CXXCodeGen
 
 CXXCodeGen::StringTreeRef operator+(

--- a/XcodeMLtoCXX/src/StringTree.h
+++ b/XcodeMLtoCXX/src/StringTree.h
@@ -68,6 +68,7 @@ StringTreeRef makeTokenNode(const std::string&);
 
 StringTreeRef insertNewLines(const std::vector<StringTreeRef>&);
 StringTreeRef separateByBlankLines(const std::vector<StringTreeRef>&);
+StringTreeRef join(const std::string&, const std::vector<StringTreeRef>&);
 
 }
 

--- a/XcodeMLtoCXX/src/SymbolBuilder.cpp
+++ b/XcodeMLtoCXX/src/SymbolBuilder.cpp
@@ -36,6 +36,10 @@ using SymbolBuilder = AttrProc<StringTreeRef, SourceInfo&>;
 
 #define DEFINE_SB(name) static StringTreeRef name(SB_ARGS)
 
+DEFINE_SB(NullProc) {
+  return makeVoidNode();
+}
+
 DEFINE_SB(typedefNameProc) {
   if (isTrueProp(node, "is_implicit", false)) {
     return makeVoidNode();
@@ -65,7 +69,7 @@ DEFINE_SB(tagnameProc) {
 const SymbolBuilder CXXSymbolBuilder(
     "sclass",
     makeInnerNode,
-    makeVoidNode,
+    NullProc,
     {
       { "typedef_name", typedefNameProc },
       { "tagname", tagnameProc },


### PR DESCRIPTION
[clang::CXXTemporaryObjectExpr](https://clang.llvm.org/doxygen/classclang_1_1CXXTemporaryObjectExpr.html)の逆変換に対応した。例:
```
// class X { X(int i, int j); };
X x = X(100, 200);
```

clang::CXXTemporaryObjectExprを逆変換で扱うために、 20e34cf71ae30c7ba29ce1d81b12babfd633d40c 以降放置されていたClangStmtHandlerをもう一度使うようにした。
仕様で定められていないが逆変換で対応しなければならない要素は今後ClangStmtHandlerで扱う。

