### PR TITLE
Add support for nested-name-specifier to CXXtoXML/XcodeMLtoCXX

### DIFF
--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -73,12 +73,10 @@ makeNnsIdentNodeForType(
       node,
       BAD_CAST "type",
       BAD_CAST (dtident.c_str()));
-  if (const auto prefix = Spec->getPrefix()) {
-    xmlNewProp(
-        node,
-        BAD_CAST "nns",
-        BAD_CAST (NTI.getNnsName(prefix).c_str()));
-  }
+  xmlNewProp(
+      node,
+      BAD_CAST "nns",
+      BAD_CAST (NTI.getNnsName(Spec).c_str()));
 
   return node;
 }

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -276,11 +276,16 @@
   <xsl:template match="name">
     <xsl:choose>
       <xsl:when test="@name_kind = 'name'">
-        <xsl:copy-of select="."/>
+        <name>
+          <xsl:copy-of select="../clangNestedNameSpecifier/@*"/>
+          <xsl:copy-of select="@*"/>
+          <xsl:value-of select="." />
+        </name>
       </xsl:when>
 
       <xsl:when test="@name_kind = 'operator'">
         <operator>
+          <xsl:copy-of select="../clangNestedNameSpecifier/@*"/>
           <xsl:copy-of select="@*"/>
           <xsl:value-of select="." />
         </operator>
@@ -288,12 +293,14 @@
 
       <xsl:when test="@name_kind = 'constructor'">
         <constructor>
+          <xsl:copy-of select="../clangNestedNameSpecifier/@*"/>
           <xsl:copy-of select="@*"/>
         </constructor>
       </xsl:when>
 
       <xsl:when test="@name_kind = 'destructor'">
         <destructor>
+          <xsl:copy-of select="../clangNestedNameSpecifier/@*"/>
           <xsl:copy-of select="@*"/>
         </destructor>
       </xsl:when>

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -15,6 +15,7 @@
 #include "XMLWalker.h"
 #include "AttrProc.h"
 #include "Symbol.h"
+#include "XcodeMlNns.h"
 #include "XcodeMlType.h"
 #include "XcodeMlEnvironment.h"
 #include "SourceInfo.h"

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -59,6 +59,22 @@ getDeclNameFromTypedNode(
   return makeTokenNode(getNameFromIdNode(node, src.ctxt));
 }
 
+static XcodeMl::CodeFragment
+getQualifiedNameFromTypedNode(
+    xmlNodePtr node,
+    const SourceInfo& src)
+{
+  const auto name = getDeclNameFromTypedNode(node, src);
+  auto nameNode = findFirst(node, "name", src.ctxt);
+  const auto ident = getPropOrNull(nameNode, "nns");
+  if (ident.hasValue()) {
+    const auto nns = src.nnsTable.at(*ident);
+    return nns->makeDeclaration(src.typeTable, src.nnsTable) + name;
+  } else {
+    return name;
+  }
+}
+
 /*!
  * \brief Traverse XcodeML node and make SymbolEntry.
  * \pre \c node is <globalSymbols> or <symbols> element.

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -414,7 +414,7 @@ makeFunctionDeclHead(xmlNodePtr node, const SourceInfo& src) {
   );
   const XMLString name(xmlNodeGetContent(nameElem));
   const XMLString kind(nameElem->name);
-  const auto nameNode = getDeclNameFromTypedNode(node, src);
+  const auto nameNode = getQualifiedNameFromTypedNode(node, src);
 
   const auto dtident = getDtidentFromTypedNode(
       node,
@@ -454,7 +454,7 @@ DEFINE_CB(functionDefinitionProc) {
 }
 
 DEFINE_CB(functionDeclProc) {
-  const auto name = getDeclNameFromTypedNode(node, src);
+  const auto name = getQualifiedNameFromTypedNode(node, src);
   const auto fnDtident = getDtidentFromTypedNode(
       node,
       src.ctxt,

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -18,6 +18,7 @@
 #include "XcodeMlNns.h"
 #include "XcodeMlType.h"
 #include "XcodeMlEnvironment.h"
+#include "NnsAnalyzer.h"
 #include "TypeAnalyzer.h"
 #include "SourceInfo.h"
 #include "CodeBuilder.h"
@@ -778,10 +779,13 @@ void buildCode(
 
   xmlNodePtr typeTableNode =
     findFirst(rootNode, "/XcodeProgram/typeTable", ctxt);
+  xmlNodePtr nnsTableNode =
+    findFirst(rootNode, "/XcodeProgram/nnsTable", ctxt);
   SourceInfo src = {
     ctxt,
     parseTypeTable(typeTableNode, ctxt, ss),
-    parseGlobalSymbols(rootNode, ctxt, ss)
+    parseGlobalSymbols(rootNode, ctxt, ss),
+    analyzeNnsTable(nnsTableNode, ctxt),
   };
 
   cxxgen::Stream out;

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -15,6 +15,7 @@
 #include "Stream.h"
 #include "StringTree.h"
 #include "Symbol.h"
+#include "XcodeMlNns.h"
 #include "XcodeMlType.h"
 #include "XcodeMlEnvironment.h"
 #include "TypeAnalyzer.h"

--- a/XcodeMLtoCXX/src/Makefile
+++ b/XcodeMLtoCXX/src/Makefile
@@ -20,7 +20,8 @@ OBJS = XcodeMlType.o \
 	StringTree.o \
 	SymbolBuilder.o \
 	SymbolAnalyzer.o \
-	ClangClassHandler.o
+	ClangClassHandler.o \
+	XcodeMlNns.o
 
 $(XCODEMLTOCXX): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) $(USEDLIBS) -o $(XCODEMLTOCXX)
@@ -48,6 +49,11 @@ TypeAnalyzer.o: \
 	XcodeMlEnvironment.h \
 	TypeAnalyzer.h \
 	XMLWalker.h
+XcodeMlNns.o: \
+	StringTree.h \
+	XcodeMlEnvironment.h \
+	XcodeMlNns.h \
+	XcodeMlType.h
 XcodeMlType.o: \
   Symbol.h \
 	TypeAnalyzer.h \

--- a/XcodeMLtoCXX/src/Makefile
+++ b/XcodeMLtoCXX/src/Makefile
@@ -14,6 +14,7 @@ OBJS = XcodeMlType.o \
 	XcodeMLtoCXX.o \
 	LibXMLUtil.o \
 	CodeBuilder.o \
+	NnsAnalyzer.o \
 	TypeAnalyzer.o \
 	XMLString.o \
 	XcodeMlEnvironment.o \
@@ -34,6 +35,7 @@ CodeBuilder.o: \
 	LibXMLUtil.h \
 	XcodeMlType.h \
 	XcodeMlEnvironment.h \
+	NnsAnalyzer.o \
 	TypeAnalyzer.h \
 	Symbol.h \
 	CodeBuilder.h \

--- a/XcodeMLtoCXX/src/NnsAnalyzer.cpp
+++ b/XcodeMLtoCXX/src/NnsAnalyzer.cpp
@@ -1,0 +1,63 @@
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include <libxml/tree.h>
+#include <libxml/xpath.h>
+#include "llvm/ADT/Optional.h"
+#include "llvm/Support/Casting.h"
+#include "LibXMLUtil.h"
+#include "StringTree.h"
+#include "XcodeMlNns.h"
+#include "XcodeMlType.h"
+#include "XcodeMlEnvironment.h"
+#include "XMLString.h"
+#include "XMLWalker.h"
+
+using NnsAnalyzer = XMLWalker<
+  void,
+  xmlXPathContextPtr,
+  XcodeMl::NnsMap&>;
+
+#define NA_ARGS const NnsAnalyzer& w __attribute__((unused)), \
+                xmlNodePtr node __attribute__((unused)), \
+                xmlXPathContextPtr ctxt __attribute__((unused)), \
+                XcodeMl::NnsMap & map __attribute__((unused))
+
+#define DEFINE_NA(name) static void name(NA_ARGS)
+
+DEFINE_NA(classNnsProc) {
+  const auto name = getProp(node, "nns");
+  const auto type = getProp(node, "type");
+  map[name] = XcodeMl::makeClassNns(
+      name,
+      nullptr,
+      type);
+}
+
+const XcodeMl::NnsMap initialNnsMap = {
+  { "global", XcodeMl::makeGlobalNns() },
+};
+
+const NnsAnalyzer XcodeMLNNSAnalyzer(
+"NnsAnalyzer",
+{
+  { "classNNS", classNnsProc },
+});
+
+XcodeMl::NnsMap
+analyzeNnsTable(
+    xmlNodePtr nnsTable,
+    xmlXPathContextPtr ctxt)
+{
+  XcodeMl::NnsMap map;
+  if (nnsTable == nullptr) {
+    return map;
+  }
+
+  auto nnsNodes = findNodes(nnsTable, "*", ctxt);
+  for (auto nnsNode : nnsNodes) {
+    XcodeMLNNSAnalyzer.walk(nnsNode, ctxt, map);
+  }
+  return map;
+}

--- a/XcodeMLtoCXX/src/NnsAnalyzer.cpp
+++ b/XcodeMLtoCXX/src/NnsAnalyzer.cpp
@@ -31,7 +31,6 @@ DEFINE_NA(classNnsProc) {
   const auto type = getProp(node, "type");
   map[name] = XcodeMl::makeClassNns(
       name,
-      nullptr,
       type);
 }
 

--- a/XcodeMLtoCXX/src/NnsAnalyzer.h
+++ b/XcodeMLtoCXX/src/NnsAnalyzer.h
@@ -1,0 +1,8 @@
+#ifndef NNSANALYZER_H
+#define NNSANALYZER_H
+
+class SourceInfo;
+
+XcodeMl::NnsMap analyzeNnsTable(xmlNodePtr, xmlXPathContextPtr);
+
+#endif /* !NNSANALYZER_H */

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -11,6 +11,7 @@ public:
   XcodeMl::Environment typeTable;
   /*! SymbolEntry stack in current scope. */
   SymbolMap symTable;
+  XcodeMl::NnsMap nnsTable;
 };
 
 #endif /* !SOURCEINFO_H */

--- a/XcodeMLtoCXX/src/SymbolAnalyzer.cpp
+++ b/XcodeMLtoCXX/src/SymbolAnalyzer.cpp
@@ -14,6 +14,7 @@
 #include "AttrProc.h"
 #include "StringTree.h"
 #include "Symbol.h"
+#include "XcodeMlNns.h"
 #include "XcodeMlType.h"
 #include "XcodeMlEnvironment.h"
 #include "SourceInfo.h"

--- a/XcodeMLtoCXX/src/SymbolBuilder.cpp
+++ b/XcodeMLtoCXX/src/SymbolBuilder.cpp
@@ -15,6 +15,7 @@
 #include "Stream.h"
 #include "StringTree.h"
 #include "Symbol.h"
+#include "XcodeMlNns.h"
 #include "XcodeMlType.h"
 #include "XcodeMlEnvironment.h"
 #include "SourceInfo.h"

--- a/XcodeMLtoCXX/src/XcodeMLtoCXX.cpp
+++ b/XcodeMLtoCXX/src/XcodeMLtoCXX.cpp
@@ -15,6 +15,7 @@
 #include "StringTree.h"
 #include "XMLString.h"
 #include "Symbol.h"
+#include "XcodeMlNns.h"
 #include "XcodeMlType.h"
 #include "XcodeMlEnvironment.h"
 #include "XMLWalker.h"

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -15,7 +15,7 @@ using CXXCodeGen::makeTokenNode;
 namespace XcodeMl {
 
 Nns::Nns(NnsKind k, const NnsRef& nr, const NnsIdent& ni):
-  parent(nr->getParent()),
+  parent(nr ? nr->getParent() : llvm::Optional<NnsIdent>()),
   kind(k),
   ident(ni)
 {}

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -129,4 +129,12 @@ makeClassNns(
   return std::make_shared<ClassNns>(ident, parent, classType);
 }
 
+NnsRef
+makeClassNns(
+    const NnsIdent& ident,
+    const DataTypeIdent& classType)
+{
+  return std::make_shared<ClassNns>(ident, nullptr, classType);
+}
+
 } // namespace XcodeMl

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -56,7 +56,7 @@ Nns::getParent() const {
 }
 
 GlobalNns::GlobalNns():
-  Nns(NnsKind::Global, nullptr, "global")
+  Nns(NnsKind::Global, NnsRef(), "global")
 {}
 
 Nns*

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -46,7 +46,7 @@ Nns::makeDeclaration(
   }
 }
 
-NnsRef
+llvm::Optional<NnsIdent>
 Nns::getParent() const {
   return parent;
 }
@@ -67,13 +67,16 @@ GlobalNns::classof(const Nns *N) {
 }
 
 CodeFragment
-GlobalNns::makeNestedNameSpec(const Environment&) const {
+GlobalNns::makeNestedNameSpec(
+    const Environment&,
+    const NnsMap&) const
+{
   return makeTokenNode("::");
 }
 
-NnsRef
+llvm::Optional<NnsIdent>
 GlobalNns::getParent() const {
-  return nullptr;
+  return llvm::Optional<NnsIdent>();
 }
 
 ClassNns::ClassNns(

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -35,14 +35,18 @@ Nns::getKind() const {
 
 CodeFragment
 Nns::makeDeclaration(
-    const Environment& env) const
+    const Environment& env,
+    const NnsMap& nnss) const
 {
-  if (auto p = getParent()) {
+  const auto par = getParent();
+  if (par.hasValue()) {
+    const auto p = nnss.at(*par);
     const auto prefix = p->makeDeclaration(
-        env);
-    return prefix + makeNestedNameSpec(env);
+        env,
+        nnss);
+    return prefix + makeNestedNameSpec(env, nnss);
   } else {
-    return makeNestedNameSpec(env);
+    return makeNestedNameSpec(env, nnss);
   }
 }
 
@@ -95,7 +99,8 @@ ClassNns::clone() const {
 
 CodeFragment
 ClassNns::makeNestedNameSpec(
-    const Environment& env) const
+    const Environment& env,
+    const NnsMap&) const
 {
   const auto T = env.at(dtident);
   const auto classT = llvm::cast<XcodeMl::ClassType>(T.get());

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -120,4 +120,13 @@ makeGlobalNns() {
   return std::make_shared<GlobalNns>();
 }
 
+NnsRef
+makeClassNns(
+    const NnsIdent& ident,
+    const NnsRef& parent,
+    const DataTypeIdent& classType)
+{
+  return std::make_shared<ClassNns>(ident, parent, classType);
+}
+
 } // namespace XcodeMl

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -27,6 +27,19 @@ Nns::getKind() const {
   return kind;
 }
 
+CodeFragment
+Nns::makeDeclaration(
+    const Environment& env) const
+{
+  if (auto p = getParent()) {
+    const auto prefix = p->makeDeclaration(
+        env);
+    return prefix + makeNestedNameSpec(env);
+  } else {
+    return makeNestedNameSpec(env);
+  }
+}
+
 NnsRef
 Nns::getParent() const {
   return parent;

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -15,7 +15,7 @@ using CXXCodeGen::makeTokenNode;
 namespace XcodeMl {
 
 Nns::Nns(NnsKind k, const NnsRef& nr, const NnsIdent& ni):
-  parent(nr),
+  parent(nr->getParent()),
   kind(k),
   ident(ni)
 {}

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -20,6 +20,12 @@ Nns::Nns(NnsKind k, const NnsRef& nr, const NnsIdent& ni):
   ident(ni)
 {}
 
+Nns::Nns(NnsKind k, const NnsIdent& par, const NnsIdent& ident):
+  parent(par),
+  kind(k),
+  ident(ident)
+{}
+
 Nns::~Nns() = default;
 
 NnsKind

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -14,7 +14,8 @@ using CXXCodeGen::makeTokenNode;
 
 namespace XcodeMl {
 
-Nns::Nns(NnsKind k, const NnsIdent& ni):
+Nns::Nns(NnsKind k, const NnsRef& nr, const NnsIdent& ni):
+  parent(nr),
   kind(k),
   ident(ni)
 {}
@@ -26,8 +27,11 @@ Nns::getKind() const {
   return kind;
 }
 
-ClassNns::ClassNns(const NnsIdent& ni, const DataTypeIdent& di):
-  Nns(NnsKind::Class, ni),
+ClassNns::ClassNns(
+    const NnsIdent& ni,
+    const NnsRef& parent,
+    const DataTypeIdent& di):
+  Nns(NnsKind::Class, parent, ni),
   dtident(di)
 {}
 

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -27,6 +27,11 @@ Nns::getKind() const {
   return kind;
 }
 
+NnsRef
+Nns::getParent() const {
+  return parent;
+}
+
 ClassNns::ClassNns(
     const NnsIdent& ni,
     const NnsRef& parent,

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -45,6 +45,31 @@ Nns::getParent() const {
   return parent;
 }
 
+GlobalNns::GlobalNns():
+  Nns(NnsKind::Global, nullptr, "global")
+{}
+
+Nns*
+GlobalNns::clone() const {
+  GlobalNns *copy = new GlobalNns(*this);
+  return copy;
+}
+
+bool
+GlobalNns::classof(const Nns *N) {
+  return N->getKind() == NnsKind::Global;
+}
+
+CodeFragment
+GlobalNns::makeNestedNameSpec(const Environment&) const {
+  return makeTokenNode("::");
+}
+
+NnsRef
+GlobalNns::getParent() const {
+  return nullptr;
+}
+
 ClassNns::ClassNns(
     const NnsIdent& ni,
     const NnsRef& parent,

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -42,7 +42,7 @@ ClassNns::clone() const {
 }
 
 CodeFragment
-ClassNns::makeDeclaration(
+ClassNns::makeNestedNameSpec(
     const Environment& env) const
 {
   const auto T = env.at(dtident);

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -115,4 +115,9 @@ ClassNns::classof(const Nns* N) {
   return N->getKind() == NnsKind::Class;
 }
 
+NnsRef
+makeGlobalNns() {
+  return std::make_shared<GlobalNns>();
+}
+
 } // namespace XcodeMl

--- a/XcodeMLtoCXX/src/XcodeMlNns.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlNns.cpp
@@ -1,0 +1,57 @@
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "llvm/ADT/Optional.h"
+#include "llvm/Support/Casting.h"
+#include "StringTree.h"
+#include "XcodeMlType.h"
+#include "XcodeMlEnvironment.h"
+
+#include "XcodeMlNns.h"
+
+using CXXCodeGen::makeTokenNode;
+
+namespace XcodeMl {
+
+Nns::Nns(NnsKind k, const NnsIdent& ni):
+  kind(k),
+  ident(ni)
+{}
+
+Nns::~Nns() = default;
+
+NnsKind
+Nns::getKind() const {
+  return kind;
+}
+
+ClassNns::ClassNns(const NnsIdent& ni, const DataTypeIdent& di):
+  Nns(NnsKind::Class, ni),
+  dtident(di)
+{}
+
+Nns*
+ClassNns::clone() const {
+  ClassNns *copy = new ClassNns(*this);
+  return copy;
+}
+
+CodeFragment
+ClassNns::makeDeclaration(
+    const Environment& env) const
+{
+  const auto T = env.at(dtident);
+  const auto classT = llvm::cast<XcodeMl::ClassType>(T.get());
+  assert(classT);
+  const auto name = classT->name();
+  assert(name.hasValue());
+  return (*name) + makeTokenNode("::");
+}
+
+bool
+ClassNns::classof(const Nns* N) {
+  return N->getKind() == NnsKind::Class;
+}
+
+} // namespace XcodeMl

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -30,10 +30,14 @@ public:
   virtual ~Nns() = 0;
   virtual Nns* clone() const = 0;
   NnsKind getKind() const;
-  CodeFragment makeDeclaration(const Environment&) const;
+  CodeFragment makeDeclaration(
+      const Environment&,
+      const NnsMap&) const;
 protected:
   Nns(const Nns&) = default;
-  virtual CodeFragment makeNestedNameSpec(const Environment&) const = 0;
+  virtual CodeFragment makeNestedNameSpec(
+      const Environment&,
+      const NnsMap&) const = 0;
   virtual llvm::Optional<NnsIdent> getParent() const;
 private:
   llvm::Optional<NnsIdent> parent;
@@ -49,7 +53,9 @@ public:
   static bool classof(const Nns *);
 protected:
   GlobalNns(const GlobalNns&) = default;
-  CodeFragment makeNestedNameSpec(const Environment&) const override;
+  CodeFragment makeNestedNameSpec(
+      const Environment&,
+      const NnsMap&) const override;
   llvm::Optional<NnsIdent> getParent() const override;
 };
 
@@ -61,7 +67,9 @@ public:
   static bool classof(const Nns *);
 protected:
   ClassNns(const ClassNns&) = default;
-  virtual CodeFragment makeNestedNameSpec(const Environment&)
+  virtual CodeFragment makeNestedNameSpec(
+      const Environment&,
+      const NnsMap&)
     const override;
 private:
   DataTypeIdent dtident;

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -25,6 +25,7 @@ public:
   virtual ~Nns() = 0;
   virtual Nns* clone() const = 0;
   NnsKind getKind() const;
+  CodeFragment makeDeclaration(const Environment&) const;
 protected:
   Nns(const Nns&) = default;
   virtual CodeFragment makeNestedNameSpec(const Environment&) const = 0;

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -14,6 +14,8 @@ class Environment;
 
 using NnsIdent = std::string;
 
+using NnsMap = std::map<NnsIdent, NnsRef>;
+
 enum class NnsKind {
   /*! global namespace */
   Global,

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -28,6 +28,7 @@ public:
 protected:
   Nns(const Nns&) = default;
   virtual CodeFragment makeNestedNameSpec(const Environment&) const = 0;
+  virtual NnsRef getParent() const;
 private:
   NnsRef parent;
   NnsKind kind;

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -21,7 +21,7 @@ enum class NnsKind {
 
 class Nns {
 public:
-  Nns(NnsKind, const NnsIdent&);
+  Nns(NnsKind, const NnsRef&, const NnsIdent&);
   virtual ~Nns() = 0;
   virtual Nns* clone() const = 0;
   NnsKind getKind() const;
@@ -29,13 +29,14 @@ public:
 protected:
   Nns(const Nns&) = default;
 private:
+  NnsRef parent;
   NnsKind kind;
   NnsIdent ident;
 };
 
 class ClassNns : public Nns {
 public:
-  ClassNns(const NnsIdent&, const DataTypeIdent&);
+  ClassNns(const NnsIdent&, const NnsRef&, const DataTypeIdent&);
   ~ClassNns() override = default;
   Nns* clone() const override;
   virtual CodeFragment makeDeclaration(const Environment&) const override;

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -75,6 +75,8 @@ private:
   DataTypeIdent dtident;
 };
 
+NnsRef makeGlobalNns();
+
 }
 
 #endif /* !XCODEMLNNS_H */

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -77,6 +77,7 @@ private:
 
 NnsRef makeGlobalNns();
 NnsRef makeClassNns(const NnsIdent&, const NnsRef&, const DataTypeIdent&);
+NnsRef makeClassNns(const NnsIdent&, const DataTypeIdent&);
 
 }
 

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -34,7 +34,7 @@ public:
 protected:
   Nns(const Nns&) = default;
   virtual CodeFragment makeNestedNameSpec(const Environment&) const = 0;
-  virtual NnsRef getParent() const;
+  virtual llvm::Optional<NnsIdent> getParent() const;
 private:
   llvm::Optional<NnsIdent> parent;
   NnsKind kind;
@@ -50,7 +50,7 @@ public:
 protected:
   GlobalNns(const GlobalNns&) = default;
   CodeFragment makeNestedNameSpec(const Environment&) const override;
-  NnsRef getParent() const override;
+  llvm::Optional<NnsIdent> getParent() const override;
 };
 
 class ClassNns : public Nns {

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -1,0 +1,51 @@
+#ifndef XCODEMLNNS_H
+#define XCODEMLNNS_H
+
+namespace XcodeMl {
+
+class Nns;
+using NnsRef = std::shared_ptr<Nns>;
+
+using CodeFragment = CXXCodeGen::StringTreeRef;
+
+using DataTypeIdent = std::string;
+
+class Environment;
+
+using NnsIdent = std::string;
+
+enum class NnsKind {
+  /*! classNNS */
+  Class,
+};
+
+class Nns {
+public:
+  Nns(NnsKind, const NnsIdent&);
+  virtual ~Nns() = 0;
+  virtual Nns* clone() const = 0;
+  NnsKind getKind() const;
+  virtual CodeFragment makeDeclaration(const Environment&) const = 0;
+protected:
+  Nns(const Nns&) = default;
+private:
+  NnsKind kind;
+  NnsIdent ident;
+};
+
+class ClassNns : public Nns {
+public:
+  ClassNns(const NnsIdent&, const DataTypeIdent&);
+  ~ClassNns() override = default;
+  Nns* clone() const override;
+  virtual CodeFragment makeDeclaration(const Environment&) const override;
+  static bool classof(const Nns *);
+protected:
+  ClassNns(const ClassNns&) = default;
+private:
+  DataTypeIdent dtident;
+};
+
+}
+
+#endif /* !XCODEMLNNS_H */

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -15,6 +15,8 @@ class Environment;
 using NnsIdent = std::string;
 
 enum class NnsKind {
+  /*! global namespace */
+  Global,
   /*! classNNS */
   Class,
 };
@@ -34,6 +36,18 @@ private:
   NnsRef parent;
   NnsKind kind;
   NnsIdent ident;
+};
+
+class GlobalNns : public Nns {
+public:
+  GlobalNns();
+  ~GlobalNns() override = default;
+  Nns* clone() const override;
+  static bool classof(const Nns *);
+protected:
+  GlobalNns(const GlobalNns&) = default;
+  CodeFragment makeNestedNameSpec(const Environment&) const override;
+  NnsRef getParent() const override;
 };
 
 class ClassNns : public Nns {

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -76,6 +76,7 @@ private:
 };
 
 NnsRef makeGlobalNns();
+NnsRef makeClassNns(const NnsIdent&, const NnsRef&, const DataTypeIdent&);
 
 }
 

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -35,7 +35,7 @@ protected:
   virtual CodeFragment makeNestedNameSpec(const Environment&) const = 0;
   virtual NnsRef getParent() const;
 private:
-  NnsRef parent;
+  llvm::Optional<NnsIdent> parent;
   NnsKind kind;
   NnsIdent ident;
 };

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -25,9 +25,9 @@ public:
   virtual ~Nns() = 0;
   virtual Nns* clone() const = 0;
   NnsKind getKind() const;
-  virtual CodeFragment makeDeclaration(const Environment&) const = 0;
 protected:
   Nns(const Nns&) = default;
+  virtual CodeFragment makeNestedNameSpec(const Environment&) const = 0;
 private:
   NnsRef parent;
   NnsKind kind;
@@ -39,10 +39,11 @@ public:
   ClassNns(const NnsIdent&, const NnsRef&, const DataTypeIdent&);
   ~ClassNns() override = default;
   Nns* clone() const override;
-  virtual CodeFragment makeDeclaration(const Environment&) const override;
   static bool classof(const Nns *);
 protected:
   ClassNns(const ClassNns&) = default;
+  virtual CodeFragment makeNestedNameSpec(const Environment&)
+    const override;
 private:
   DataTypeIdent dtident;
 };

--- a/XcodeMLtoCXX/src/XcodeMlNns.h
+++ b/XcodeMLtoCXX/src/XcodeMlNns.h
@@ -26,6 +26,7 @@ enum class NnsKind {
 class Nns {
 public:
   Nns(NnsKind, const NnsRef&, const NnsIdent&);
+  Nns(NnsKind, const NnsIdent&, const NnsIdent&);
   virtual ~Nns() = 0;
   virtual Nns* clone() const = 0;
   NnsKind getKind() const;


### PR DESCRIPTION
* 正変換への入力プログラムで使われているnested-name-specifierについて、NNS識別名を発行しnnsTableに登録する
* XcodeMl::Nnsクラスとその派生クラスを定義する
* 逆変換において、nns属性が与えられているname要素に対してnested-name-specifierを付けた名前を出力する