### PR TITLE
Modify `a.b` to `&(a)->b` by XSLT

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -108,6 +108,10 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
     newProp("clangCastKind", CE->getCastKindName());
   }
 
+  if (auto ME = dyn_cast<clang::MemberExpr>(S)) {
+    newBoolProp("is_arrow", ME->isArrow());
+  }
+
   if (auto CL = dyn_cast<CharacterLiteral>(S)) {
     newProp("hexadecimalNotation",
         unsignedToHexString(CL->getValue()).c_str());

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -264,13 +264,28 @@
   </xsl:template>
 
   <xsl:template match="clangStmt[@class='MemberExpr']">
-    <memberRef>
-      <xsl:apply-templates select="@*" />
-      <xsl:attribute name="member">
-        <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
-      </xsl:attribute>
-      <xsl:apply-templates select="*[2]" />
-    </memberRef>
+    <xsl:choose>
+      <xsl:when test="@is_arrow = '1' or @is_arrow = 'true'">
+        <memberRef>
+          <xsl:apply-templates select="@*" />
+          <xsl:attribute name="member">
+            <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
+          </xsl:attribute>
+          <xsl:apply-templates select="*[2]" />
+        </memberRef>
+      </xsl:when>
+      <xsl:otherwise>
+        <memberRef>
+          <xsl:apply-templates select="@*" />
+          <xsl:attribute name="member">
+            <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
+          </xsl:attribute>
+          <AddrOfExpr is_expedient="1">
+            <xsl:apply-templates select="*[2]" />
+          </AddrOfExpr>
+        </memberRef>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="name">

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -264,13 +264,26 @@
   </xsl:template>
 
   <xsl:template match="clangStmt[@class='MemberExpr']">
-    <memberRef>
-      <xsl:apply-templates select="@*" />
-      <xsl:attribute name="member">
-        <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
-      </xsl:attribute>
-      <xsl:apply-templates select="*[2]" />
-    </memberRef>
+    <xsl:choose>
+      <xsl:when test="(@is_arrow = '1') or (@is_arrow = 'true')">
+        <arrowExpr>
+          <xsl:apply-templates select="@*" />
+          <xsl:attribute name="member">
+            <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
+          </xsl:attribute>
+          <xsl:apply-templates select="*[2]" />
+        </arrowExpr>
+      </xsl:when>
+      <xsl:otherwise>
+        <memberRef>
+          <xsl:apply-templates select="@*" />
+          <xsl:attribute name="member">
+            <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
+          </xsl:attribute>
+          <xsl:apply-templates select="*[2]" />
+        </memberRef>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="name">

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -264,26 +264,13 @@
   </xsl:template>
 
   <xsl:template match="clangStmt[@class='MemberExpr']">
-    <xsl:choose>
-      <xsl:when test="(@is_arrow = '1') or (@is_arrow = 'true')">
-        <arrowExpr>
-          <xsl:apply-templates select="@*" />
-          <xsl:attribute name="member">
-            <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
-          </xsl:attribute>
-          <xsl:apply-templates select="*[2]" />
-        </arrowExpr>
-      </xsl:when>
-      <xsl:otherwise>
-        <memberRef>
-          <xsl:apply-templates select="@*" />
-          <xsl:attribute name="member">
-            <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
-          </xsl:attribute>
-          <xsl:apply-templates select="*[2]" />
-        </memberRef>
-      </xsl:otherwise>
-    </xsl:choose>
+    <memberRef>
+      <xsl:apply-templates select="@*" />
+      <xsl:attribute name="member">
+        <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
+      </xsl:attribute>
+      <xsl:apply-templates select="*[2]" />
+    </memberRef>
   </xsl:template>
 
   <xsl:template match="name">

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -457,13 +457,6 @@ DEFINE_CB(memberRefProc) {
     makeTokenNode(getProp(node, "member"));
 }
 
-DEFINE_CB(arrowExprProc) {
-  return
-    makeInnerNode(w.walkChildren(node, src)) +
-    makeTokenNode("->") +
-    makeTokenNode(getProp(node, "member"));
-}
-
 DEFINE_CB(memberAddrProc) {
   return
     makeTokenNode("&") +
@@ -760,7 +753,6 @@ makeInnerNode,
   { "classDecl", emitClassDefinition },
 
   /* out of specification */
-  { "arrowExpr", arrowExprProc },
   { "constructorInitializer", ctorInitProc },
   { "constructorInitializerList", ctorInitListProc },
 

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -457,6 +457,13 @@ DEFINE_CB(memberRefProc) {
     makeTokenNode(getProp(node, "member"));
 }
 
+DEFINE_CB(arrowExprProc) {
+  return
+    makeInnerNode(w.walkChildren(node, src)) +
+    makeTokenNode("->") +
+    makeTokenNode(getProp(node, "member"));
+}
+
 DEFINE_CB(memberAddrProc) {
   return
     makeTokenNode("&") +
@@ -753,6 +760,7 @@ makeInnerNode,
   { "classDecl", emitClassDefinition },
 
   /* out of specification */
+  { "arrowExpr", arrowExprProc },
   { "constructorInitializer", ctorInitProc },
   { "constructorInitializerList", ctorInitListProc },
 

--- a/tests/Compilability/member_access.src.cpp
+++ b/tests/Compilability/member_access.src.cpp
@@ -1,0 +1,7 @@
+struct ClassA {
+  int member;
+};
+
+void func(ClassA a) {
+  a.member = 100;
+}


### PR DESCRIPTION
~`a->b` に対して~
```
<arrowExpr member="b">
  <Var>a</Var>
</arrowExpr>
```
~を出力する。~
~この挙動はC_Frontとは異なる。~