### PR TITLE
 Ignore class member with no access specifier in XcodeMLtoCXX

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -273,6 +273,8 @@ DeclarationsVisitor::PreVisitDecl(Decl *D) {
   }
   if (D->getAccess() != AS_none) {
     newProp("access", AccessSpec(D->getAccess()).c_str());
+  } else {
+    newBoolProp("clang_access_none", true);
   }
 
   if (isa<TranslationUnitDecl>(D)) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -367,7 +367,13 @@ DEFINE_CB(emitClassDefinition) {
   for (xmlNodePtr memberNode = xmlFirstElementChild(node);
        memberNode;
        memberNode = xmlNextElementSibling(memberNode)) {
-    const auto access = getProp(memberNode, "access");
+    const auto accessProp = getPropOrNull(memberNode, "access");
+    if (!accessProp.hasValue()) {
+      return
+        makeTokenNode("/* ignored a member with no access specifier */") +
+        makeNewLineNode();
+    }
+    const auto access = *accessProp;
     const auto decl =
       makeTokenNode(access) +
       makeTokenNode(":") +


### PR DESCRIPTION
クラス定義に対して、clangが有効なアクセス指定のない暗黙のclang::Declを挿入することがあり、逆変換のエラーの原因になります。これは逆変換がclassDecl要素の全ての子要素にaccess属性が与えられていることを期待しているためです。例：
```
class A {
  // ここに `CXXRecordDecl 0x....... parent class B` が挿入される
  class B* ptr;
};
```

一時的な処置として、逆変換においてaccess属性のないclassDeclの子要素を無視します。