### PR TITLE
Don't emit empty parenthesis for the initializer of a declarator

### DIFF
--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -717,11 +717,20 @@ DEFINE_CB(varDeclProc) {
         "clangStmt[@class='CXXConstructExpr']",
         src.ctxt))
   {
+    const auto args = w.walkChildren(ctorExpr, src);
+    /*
+     * X a();  // illegal ([dcl.init]/6)
+     * X a;    // OK
+     */
+    const auto init =
+      args.empty() ?
+        makeVoidNode()
+      : makeTokenNode("(") +
+        cxxgen::join(",", args) +
+        makeTokenNode(")");
     acc =
       acc +
-      makeTokenNode("(") +
-      cxxgen::join(",", w.walkChildren(ctorExpr, src)) +
-      makeTokenNode(")") +
+      init +
       makeTokenNode(";");
     return wrapWithLangLink(acc, node);
   }


### PR DESCRIPTION
宣言の初期化子として空の括弧式を用いることはできません。例：
```
X a(); // X型のオブジェクトではなくX型の返り値をもつ関数を宣言している
```

代わりに以下のように出力します。
```
X a;
```