### PR TITLE
add "make prepare-cpptest", "make check-cpptest", "make clean-cpptest" and "make build"

### DIFF
--- a/tests/CCTest/Makefile
+++ b/tests/CCTest/Makefile
@@ -1,17 +1,23 @@
 .SUFFIXES: .xcodeml
-.PHONY: check clean install-cc
+.PHONY: check clean prepare-cpptest check-cpptest clean-cpptest build
 .DELETE_ON_ERROR:
 
 all: check
 
 ROOTDIR = ../..
 CXXTOXML = $(ROOTDIR)/scripts/CXXtoXcodeML
-CXXTOXMLFLAGS = --
+CXXTOXML_INCLUDES = -I.
+CXXTOXMLFLAGS = -- -Wall -W -w $(CXXTOXML_INCLUDES)
 XCODEMLTOCXXDIR = $(ROOTDIR)/XcodeMLtoCXX
 XCODEMLTOCXX = $(XCODEMLTOCXXDIR)/XcodeMLtoCXX
 CXXTESTCASES = $(wildcard *.src.cpp)
 CXXDECOMPTESTOBJECTS = $(CXXTESTCASES:.src.cpp=.dst.cpp)
 CXXFLAGS = -pedantic -fsyntax-only
+
+CPPTEST_TARBALL = ../../../CppTest.tar.gz
+CPPTEST_EXTRACT_DIR = CppTest
+TESTOBJECTS_TXT = testobjects.txt
+EXAMINE_SH = ./examine.sh
 
 %.xml: %.src.cpp
 	../../CXXtoXML/src/CXXtoXML $< $(CXXTOXMLFLAGS) > $@
@@ -23,11 +29,6 @@ CXXFLAGS = -pedantic -fsyntax-only
 %.dst.cpp: %.xcodeml
 	$(XCODEMLTOCXX) $< > $@
 
-install-cc:
-	for file in *.cc; do \
-		mv $$file $${file%.cc}.src.cpp; \
-	done
-
 check: $(CXXDECOMPTESTOBJECTS)
 	set -e; \
 	for testobj in $(CXXDECOMPTESTOBJECTS); do  \
@@ -35,4 +36,27 @@ check: $(CXXDECOMPTESTOBJECTS)
 	done
 
 clean:
-	rm -f *.xml *.dst.cpp *.xcodeml
+	rm -rf *.xml *.dst.cpp *.xcodeml
+
+build:
+	(cd $(ROOTDIR)/CXXtoXML/src; make clean; make)
+	(cd $(ROOTDIR)/XcodeMLtoCXX/src; make clean; make)
+
+prepare-cpptest: $(CPPTEST_TARBALL) $(TESTOBJECTS_TXT)
+	tar xvf $(CPPTEST_TARBALL)
+	@cat $(TESTOBJECTS_TXT) | while read line; do \
+	   sed 's/^main/int main/' $(CPPTEST_EXTRACT_DIR)/$${line}.cc > $${line}.src.cpp; \
+	done
+
+check-cpptest:
+	@cat $(TESTOBJECTS_TXT) | while read line; do \
+	  sh $(EXAMINE_SH) $${line}; \
+	done 2> err.log | tee result.csv
+
+clean-cpptest: clean
+	@if [ -d $(CPPTEST_EXTRACT_DIR) ]; then \
+	   (cd $(CPPTEST_EXTRACT_DIR); for file in *; do \
+	       rm -f $$file ../$${file%.cc}.src.cpp ../$${file%.cc}.out; \
+	    done); rmdir $(CPPTEST_EXTRACT_DIR); \
+	 fi
+	rm -f err.log result.csv

--- a/tests/CCTest/Makefile
+++ b/tests/CCTest/Makefile
@@ -45,7 +45,8 @@ build:
 prepare-cpptest: $(CPPTEST_TARBALL) $(TESTOBJECTS_TXT)
 	tar xvf $(CPPTEST_TARBALL)
 	@cat $(TESTOBJECTS_TXT) | while read line; do \
-	   sed 's/^main/int main/' $(CPPTEST_EXTRACT_DIR)/$${line}.cc > $${line}.src.cpp; \
+	   sed 's/^main/int main/' $(CPPTEST_EXTRACT_DIR)/$${line}.cc \
+	      > $${line}.src.cpp; \
 	done
 
 check-cpptest:
@@ -53,10 +54,12 @@ check-cpptest:
 	  sh $(EXAMINE_SH) $${line}; \
 	done 2> err.log | tee result.csv
 
-clean-cpptest: clean
-	@if [ -d $(CPPTEST_EXTRACT_DIR) ]; then \
+clean-cpptest:
+	if [ -d $(CPPTEST_EXTRACT_DIR) ]; then \
 	   (cd $(CPPTEST_EXTRACT_DIR); for file in *; do \
-	       rm -f $$file ../$${file%.cc}.src.cpp ../$${file%.cc}.out; \
+	       rm -f $$file ../$${file%.cc}.src.cpp \
+	         ../$${file%.cc}.xml ../$${file%.cc}.xcodeml \
+	         ../$${file%.cc}.dst.cpp ../$${file%.cc}.out; \
 	    done); rmdir $(CPPTEST_EXTRACT_DIR); \
 	 fi
 	rm -f err.log result.csv

--- a/tests/CCTest/examine.sh
+++ b/tests/CCTest/examine.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+abort() {
+  echo "$@"
+  exit 1
+}
+
+target="$1"
+
+echo -n "${target}.cc,"
+
+make "${target}.xcodeml" >&2 || abort 'CXXtoXcodeML fail'
+make "${target}.dst.cpp" >&2 || abort 'XcodeMLtoCXX fail'
+
+echo -n 'OK,' # CXX -> XML conversion was correctly done
+
+clang++ -o "${target}.out" "${target}.dst.cpp" || abort 'Compilation fail'
+
+echo -n 'OK, ' # XML -> C++ conversion was correctly done
+
+echo $(./"${target}.out")

--- a/tests/CCTest/stddef.h
+++ b/tests/CCTest/stddef.h
@@ -1,0 +1,6 @@
+#ifndef __STDDEF_H_INCLUDED__
+#define __STDDEF_H_INCLUDED__
+typedef long int ptrdiff_t;
+typedef long unsigned int size_t;
+typedef int wchar_t;
+#endif

--- a/tests/CCTest/stdio.h
+++ b/tests/CCTest/stdio.h
@@ -1,0 +1,2 @@
+extern "C" int printf(const char *, ...);
+extern "C" int puts(char *);

--- a/tests/CCTest/stdlib.h
+++ b/tests/CCTest/stdlib.h
@@ -1,0 +1,6 @@
+#ifndef __STDLIB_H_INCLUDED__
+#define __STDLIB_H_INCLUDED__
+#include <stddef.h>
+void *malloc(size_t);
+void free(void *);
+#endif


### PR DESCRIPTION
tests/CCTest ディレクトリの中だけでテストが完結できるようにしました。

* make build
  CXXtoXML と XcodeMLtoCXX をリビルドします。
* make prepare-cpptest
  … ../../../CppTest.tar.gz があるものだとして、それを CCTest/ 内の CppTest/ として展開し、
 そこから *.src.cpp を作成します。 (main は int main にする)
* make check-cpptest
  従来の check.sh の動きをします。ただし動作中に標準出力「にも」 CSV を吐きます。
  補助スクリプトとして check.sh の examine() 関数と print_line() 関数の動きをする examine.sh を使います。
* make clean-cpptest
  CCTest/ 内の CppTest/ ディレクトリがあれば、そこから作成されたと考えられる .src.cpp, .xml, .xcodeml,  .dst.cpp と .out を削除し、 err.log, result.csv も削除し、 CppTest/ ディレクトリも消します。

Makefile 中の install-cc は削除しました。
また、 check.sh は不要になります（が、念のため残してあります）。