### PR TITLE
Specify the target of xsl:template application in Program2XcodeProgram.xsl

### DIFF
--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -68,7 +68,7 @@
       <constructorInitializer>
         <xsl:copy-of select="@*" /> <!-- including @member -->
         <xsl:apply-templates select="@xcodemlType" />
-        <xsl:apply-templates select="*" />
+        <xsl:apply-templates select="clangStmt[1]" />
       </constructorInitializer>
     </xsl:if>
   </xsl:template>


### PR DESCRIPTION
Fix `xsl:template[@match="clangConstructorInitializer"]`.

If a `clangConstructorInitializer` represents a base class initializer, the first child element of it is not `clangStmt` but `TypeLoc`.

Example:

```
class A {
public:
  A(int, int);
};

class B : public A {
  B(int i) : A(i, i), num(i) { }
  int num;
};
```

```
- clangDecl[@class="CXXConstructor"] (B::B)
  - name (B)
  - clangDeclarationNameInfo (B)
  - TypeLoc (void(int))
    - TypeLoc (void)
    - clangDecl[@class="ParmVar"]
      - name (i)
        - TypeLoc (int)
  - clangConstructorInitializer (A(i, i))
    - *TypeLoc* (A)
    - clangStmt[@class="CXXConstructExpr"]
      - clangStmt[@class="ImplicitCastExpr"]
        - clangStmt[@class="DeclRefExpr"]
          - clangDeclarationNameInfo (i)
      - clangStmt[@class="ImplicitCastExpr"]
        - clangStmt[@class="DeclRefExpr"]
          - clangDeclarationNameInfo (i)
  - clangConstructorInitializer (num(i))
    - *clangStmt[@class="ImplicitCastExpr"]* (i)
      - clangStmt[@class="DeclRefExpr"]
        - clangDeclarationNameInfo (i)
```