### PR TITLE
Emit "xcodemlAccessToAnonRecordExpr" elements

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -110,6 +110,11 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
 
   if (auto ME = dyn_cast<clang::MemberExpr>(S)) {
     newBoolProp("is_arrow", ME->isArrow());
+
+    if (const auto DRE = dyn_cast<clang::DeclRefExpr>(ME->getBase())) {
+      const auto DN = DRE->getNameInfo().getName();
+      newBoolProp("is_access_to_anon_record", DN.isEmpty());
+    }
   }
 
   if (auto CL = dyn_cast<CharacterLiteral>(S)) {

--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -418,6 +418,7 @@ DeclarationsVisitor::PreVisitDeclarationNameInfo(DeclarationNameInfo NI) {
   newChild("clangDeclarationNameInfo",
           II ? II->getNameStart() : nullptr);
   newProp("class", NameForDeclarationName(DN));
+  newBoolProp("is_empty", DN.isEmpty());
   return true;
 }
 

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -305,6 +305,10 @@
   </xsl:template>
 
   <xsl:template match="clangStmt[@class='MemberExpr']">
+    <xsl:variable
+      name="is_anon"
+      select="(@is_access_to_anon_record = '1')
+              or (@is_access_to_anon_record = 'true')" />
     <memberRef>
       <xsl:apply-templates select="@*" />
       <xsl:attribute name="member">

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -334,6 +334,7 @@
       </xsl:if>
 
       <xsl:choose>
+        <xsl:when test="$is_anon" />
         <xsl:when test="@is_arrow = '1' or @is_arrow = 'true'">
           <xsl:apply-templates select="clangStmt" />
         </xsl:when>

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -309,6 +309,15 @@
       name="is_anon"
       select="(@is_access_to_anon_record = '1')
               or (@is_access_to_anon_record = 'true')" />
+    <xsl:variable
+      name="elemName"
+      select="concat(substring('xcodemlAccessToAnonRecordExpr',
+                               1 div $is_anon),
+                     substring('memberRef',
+                               1 div not($is_anon)))"/>
+    <!-- "if ($is_anon)
+         then ('xcodemlAccessToAnonRecordExpr')
+         else ('memberRef')" -->
     <memberRef>
       <xsl:apply-templates select="@*" />
       <xsl:attribute name="member">

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -318,7 +318,7 @@
     <!-- "if ($is_anon)
          then ('xcodemlAccessToAnonRecordExpr')
          else ('memberRef')" -->
-    <memberRef>
+    <xsl:element name="{$elemName}">
       <xsl:apply-templates select="@*" />
       <xsl:attribute name="member">
         <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
@@ -343,7 +343,7 @@
           </AddrOfExpr>
         </xsl:otherwise>
       </xsl:choose>
-    </memberRef>
+    </xsl:element>
   </xsl:template>
 
   <xsl:template match="name">

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -879,6 +879,15 @@ DEFINE_CB(ctorInitProc) {
     makeTokenNode(")");
 }
 
+DEFINE_CB(accessToAnonRecordExprProc) {
+  const auto baseName = getProp(node, "member");
+  const auto nnsident = getPropOrNull(node, "nns");
+  return (nnsident.hasValue() ?
+            makeNestedNameSpec(*nnsident, src)
+          : makeVoidNode())
+    + makeTokenNode(baseName);
+}
+
 DEFINE_CB(clangStmtProc) {
   return ClangStmtHandler.walk(node, w, src);
 }
@@ -967,6 +976,7 @@ makeInnerNode,
   /* out of specification */
   { "constructorInitializer", ctorInitProc },
   { "constructorInitializerList", ctorInitListProc },
+  { "xcodemlAccessToAnonRecordExpr", accessToAnonRecordExprProc},
 
   /* for elements defined by clang */
   { "clangStmt", clangStmtProc },


### PR DESCRIPTION
[無名union](https://ezoeryou.github.io/cpp-book/C++11-Syntax-and-Feature.xhtml#anonymous_union)のメンバーへのアクセスを表現する要素がXcodeMLに存在しなかったので、xcodemlAccessToAnonRecordExpr要素を追加して対応しました。