### PR TITLE
Remove definition of wchar_t

### DIFF
--- a/tests/CCTest/stddef.h
+++ b/tests/CCTest/stddef.h
@@ -2,5 +2,4 @@
 #define __STDDEF_H_INCLUDED__
 typedef long int ptrdiff_t;
 typedef long unsigned int size_t;
-typedef int wchar_t;
 #endif


### PR DESCRIPTION
`wchar_t` is a C++ keyword.