### PR TITLE
Add XcodeMlNameElem to CXXtoXML

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -3,6 +3,7 @@
 #include "DeclarationsVisitor.h"
 #include "InheritanceInfo.h"
 #include "NnsTableInfo.h"
+#include "XcodeMlNameElem.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Lex/Lexer.h"
 #include <map>
@@ -300,26 +301,8 @@ DeclarationsVisitor::PreVisitDecl(Decl *D) {
 
   NamedDecl *ND = dyn_cast<NamedDecl>(D);
   if (ND) {
-    auto nameNode = addChild("name", ND->getNameAsString().c_str());
-    xmlNewProp(
-        nameNode,
-        BAD_CAST "fullName",
-        BAD_CAST ND->getQualifiedNameAsString().c_str());
-    xmlNewProp(
-        nameNode,
-        BAD_CAST "name_kind",
-        BAD_CAST getNameKind(ND));
-    if (ND->isLinkageValid()) {
-      const auto FL = ND->getFormalLinkage(),
-                 LI = ND->getLinkageInternal();
-      newProp("linkage", stringifyLinkage(FL));
-      if (FL != LI) {
-        newProp("clang_linkage_internal", stringifyLinkage(LI));
-      }
-    } else {
-      // should not be executed
-      newBoolProp("clang_has_invalid_linkage", true);
-    }
+    auto nameNode = makeNameNode(*typetableinfo, ND);
+    xmlAddChild(curNode, nameNode);
   }
 
   if (auto UD = dyn_cast<UsingDecl>(D)) {

--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -248,24 +248,6 @@ DeclarationsVisitor::PreVisitAttr(Attr *A) {
 }
 
 static const char*
-getNameKind(NamedDecl* ND) {
-  auto FD = dyn_cast<FunctionDecl>(ND);
-  if (!FD) {
-    return "name";
-  }
-  if (FD->isOverloadedOperator()) {
-    return "operator";
-  }
-  if (isa<CXXConstructorDecl>(FD)) {
-    return "constructor";
-  }
-  if (isa<CXXDestructorDecl>(FD)) {
-    return "destructor";
-  }
-  return "name";
-}
-
-static const char*
 getLanguageIdAsString(clang::LinkageSpecDecl::LanguageIDs id) {
   using clang::LinkageSpecDecl;
   switch(id) {

--- a/CXXtoXML/src/Makefile
+++ b/CXXtoXML/src/Makefile
@@ -26,6 +26,7 @@ OBJS =  CXXtoXML.o \
 	DeclarationsVisitor.o \
 	InheritanceInfo.o \
 	NnsTableInfo.o \
+	XcodeMlNameElem.o \
 	ClangOperator.o
 
 CXXtoXML: $(RAVOBJS) $(OBJS)

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -247,15 +247,8 @@ makeSymbolsNodeForRecordType(
        * Some field does not have name.
        *  Example: `struct A { int : 0; }; // unnamed bit field`
        */
-      auto nameNode = xmlNewChild(
-          idNode,
-          nullptr,
-          BAD_CAST "name",
-          BAD_CAST fieldName->getName().data());
-      xmlNewProp(
-          nameNode,
-          BAD_CAST "name_kind",
-          BAD_CAST "name");
+      auto nameNode = makeNameNode(TTI, field);
+      xmlAddChild(idNode, nameNode);
     }
     xmlAddChild(symbolsNode, idNode);
   }

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -562,15 +562,11 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
       const auto constantName = name->getIdentifier();
       assert(constantName);
       auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
-      auto nameNode = xmlNewChild(
+      xmlNewChild(
           idNode,
           nullptr,
           BAD_CAST "name",
           BAD_CAST constantName->getName().data());
-      xmlNewProp(
-          nameNode,
-          BAD_CAST "name_kind",
-          BAD_CAST "name");
       xmlAddChild(symbolsNode, idNode);
     }
     xmlAddChild(Node, symbolsNode);

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -203,27 +203,7 @@ makeSymbolsNodeForCXXRecordDecl(
 
   // data members
   for (auto&& field : def->fields()) {
-    auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
-    xmlNewProp(
-        idNode,
-        BAD_CAST "type",
-        BAD_CAST TTI.getTypeName(field->getType()).c_str());
-    const auto fieldName = field->getIdentifier();
-    if (fieldName) {
-      /* Emit only if the field has name.
-       * Some field does not have name.
-       *  Example: `struct A { int : 0; }; // unnamed bit field`
-       */
-      auto nameNode = xmlNewChild(
-          idNode,
-          nullptr,
-          BAD_CAST "name",
-          BAD_CAST fieldName->getName().data());
-      xmlNewProp(
-          nameNode,
-          BAD_CAST "name_kind",
-          BAD_CAST "name");
-    }
+    auto idNode = makeIdNodeForFieldDecl(TTI, field);
     xmlAddChild(symbolsNode, idNode);
   }
 

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -479,24 +479,7 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
             BAD_CAST (FT->isRestrict() ? "1" : "0"));
       }
       if (auto FTP = dyn_cast<FunctionProtoType>(FT)) {
-        auto paramsNode = xmlNewNode(nullptr, BAD_CAST "params");
-        for (auto& paramT : FTP->getParamTypes()) {
-          auto paramNode = xmlNewNode(nullptr, BAD_CAST "name");
-            // FIXME: Add content (parameter name) to <name> element
-          xmlNewProp(
-              paramNode,
-              BAD_CAST "type",
-              BAD_CAST getTypeName(paramT).c_str());
-          xmlNewProp(
-              paramNode,
-              BAD_CAST "name_kind",
-              BAD_CAST "name");
-          xmlAddChild(paramsNode, paramNode);
-        }
-        if (FTP->isVariadic()) {
-          auto ellipNode = xmlNewNode(nullptr, BAD_CAST "ellipsis");
-          xmlAddChild(paramsNode, ellipNode);
-        }
+        auto paramsNode = makeFunctionTypeParamsNode(*this, FTP);
         xmlAddChild(Node, paramsNode);
       }
       pushType(T, Node);

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -2,6 +2,7 @@
 #include "DeclarationsVisitor.h"
 #include "ClangOperator.h"
 #include "TypeTableInfo.h"
+#include "XcodeMlNameElem.h"
 
 #include <iostream>
 #include <sstream>
@@ -186,59 +187,6 @@ getTagKindAsString(clang::TagTypeKind ttk) {
     case TTK_Interface:
       return "__interface__";
   }
-}
-
-static xmlNodePtr
-makeNameNodeForCXXMethodDecl(
-    TypeTableInfo&,
-    const CXXMethodDecl* MD)
-{
-  auto nameNode = xmlNewNode(nullptr, BAD_CAST "name");
-  if (isa<CXXConstructorDecl>(MD)) {
-    xmlNewProp(
-        nameNode,
-        BAD_CAST "name_kind",
-        BAD_CAST "constructor");
-    return nameNode;
-  } else if (isa<CXXDestructorDecl>(MD)) {
-    xmlNewProp(
-        nameNode,
-        BAD_CAST "name_kind",
-        BAD_CAST "destructor");
-    return nameNode;
-  } else if (auto OOK = MD->getOverloadedOperator()) {
-    xmlNewProp(
-        nameNode,
-        BAD_CAST "name_kind",
-        BAD_CAST "operator");
-    xmlNodeAddContent(
-        nameNode,
-        BAD_CAST OverloadedOperatorKindToString(OOK, MD->param_size()));
-    return nameNode;
-  }
-  const auto ident = MD->getIdentifier();
-  assert(ident);
-  xmlNodeAddContent(nameNode, BAD_CAST ident->getName().data());
-  xmlNewProp(
-      nameNode,
-      BAD_CAST "name_kind",
-      BAD_CAST "name");
-  return nameNode;
-}
-
-static xmlNodePtr
-makeIdNodeForCXXMethodDecl(
-    TypeTableInfo& TTI,
-    const CXXMethodDecl* method)
-{
-  auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
-  xmlNewProp(
-      idNode,
-      BAD_CAST "type",
-      BAD_CAST TTI.getTypeName(method->getType()).c_str());
-  auto nameNode = makeNameNodeForCXXMethodDecl(TTI, method);
-  xmlAddChild(idNode, nameNode);
-  return idNode;
 }
 
 static xmlNodePtr

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -479,7 +479,21 @@ void TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
             BAD_CAST (FT->isRestrict() ? "1" : "0"));
       }
       if (auto FTP = dyn_cast<FunctionProtoType>(FT)) {
-        auto paramsNode = makeFunctionTypeParamsNode(*this, FTP);
+        auto paramsNode = xmlNewNode(nullptr, BAD_CAST "params");
+        for (auto& paramT : FTP->getParamTypes()) {
+          auto paramNode = xmlNewNode(
+              nullptr,
+              BAD_CAST "paramTypeName");
+          xmlNewProp(
+              paramNode,
+              BAD_CAST "type",
+              BAD_CAST getTypeName(paramT).c_str());
+          xmlAddChild(paramsNode, paramNode);
+        }
+        if (FTP->isVariadic()) {
+          auto ellipNode = xmlNewNode(nullptr, BAD_CAST "ellipsis");
+          xmlAddChild(paramsNode, ellipNode);
+        }
         xmlAddChild(Node, paramsNode);
       }
       pushType(T, Node);

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -20,6 +20,12 @@
     </enumType>
   </xsl:template>
 
+  <xsl:template match="paramTypeName">
+    <name>
+      <xsl:copy-of select="@type" />
+    </name>
+  </xsl:template>
+
   <xsl:template match="clangDecl[@class='TranslationUnit']">
     <globalDeclarations>
       <xsl:apply-templates />

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -101,3 +101,30 @@ makeIdNodeForCXXMethodDecl(
   return idNode;
 }
 
+xmlNodePtr
+makeIdNodeForFieldDecl(
+    TypeTableInfo& TTI,
+    const FieldDecl* field)
+{
+  auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
+  xmlNewProp(
+      idNode,
+      BAD_CAST "type",
+      BAD_CAST TTI.getTypeName(field->getType()).c_str());
+  const auto fieldName = field->getIdentifier();
+  if (fieldName) {
+    /* Emit only if the field has name.
+     * Some field does not have name.
+     *  Example: `struct A { int : 0; }; // unnamed bit field`
+     */
+    auto nameNode = xmlNewChild(
+        idNode,
+        nullptr,
+        BAD_CAST "name",
+        BAD_CAST fieldName->getName().data());
+    xmlNewProp(
+        nameNode,
+        BAD_CAST "name_kind",
+        BAD_CAST "name");
+  }
+}

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -1,0 +1,92 @@
+#include "XcodeMlNameElem.h"
+
+xmlNodePtr
+makeNameNode(
+    TypeTableInfo&,
+    const NamedDecl* ND)
+{
+  xmlNodePtr node = nullptr;
+  if (auto MD = dyn_cast<CXXMethodDecl>(ND)) {
+    node = makeNameNodeForCXXMethodDecl(MD);
+  } else {
+    node = xmlNewNode(nullptr, BAD_CAST "name");
+    xmlNodeSetContent(node, BAD_CAST (ND->getNameAsString().c_str()));
+  }
+
+  if (ND->isLinkageValid()) {
+    const auto FL = ND->getFormalLinkage(),
+               LI = ND->getLinkageInternal();
+    xmlNewProp(
+        node,
+        BAD_CAST "linkage",
+        stringifyLinkage(FL));
+    if (FL != LI) {
+      xmlNewProp(
+          node,
+          BAD_CAST "clang_linkage_internal",
+          stringifyLinkage(LI));
+    }
+  } else {
+    // should not be executed
+    xmlNewProp(
+        node,
+        BAD_CAST "clang_has_invalid_linkage",
+        BAD_CAST "true");
+  }
+
+  return node;
+}
+
+xmlNodePtr
+makeNameNodeForCXXMethodDecl(
+    TypeTableInfo&,
+    const CXXMethodDecl* MD)
+{
+  auto nameNode = xmlNewNode(nullptr, BAD_CAST "name");
+  if (isa<CXXConstructorDecl>(MD)) {
+    xmlNewProp(
+        nameNode,
+        BAD_CAST "name_kind",
+        BAD_CAST "constructor");
+    return nameNode;
+  } else if (isa<CXXDestructorDecl>(MD)) {
+    xmlNewProp(
+        nameNode,
+        BAD_CAST "name_kind",
+        BAD_CAST "destructor");
+    return nameNode;
+  } else if (auto OOK = MD->getOverloadedOperator()) {
+    xmlNewProp(
+        nameNode,
+        BAD_CAST "name_kind",
+        BAD_CAST "operator");
+    xmlNodeAddContent(
+        nameNode,
+        BAD_CAST OverloadedOperatorKindToString(OOK, MD->param_size()));
+    return nameNode;
+  }
+  const auto ident = MD->getIdentifier();
+  assert(ident);
+  xmlNodeAddContent(nameNode, BAD_CAST ident->getName().data());
+  xmlNewProp(
+      nameNode,
+      BAD_CAST "name_kind",
+      BAD_CAST "name");
+  return nameNode;
+}
+
+xmlNodePtr
+makeIdNodeForCXXMethodDecl(
+    TypeTableInfo& TTI,
+    const CXXMethodDecl* method)
+{
+  auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
+  xmlNewProp(
+      idNode,
+      BAD_CAST "type",
+      BAD_CAST TTI.getTypeName(method->getType()).c_str());
+  auto nameNode = makeNameNodeForCXXMethodDecl(TTI, method);
+  xmlAddChild(idNode, nameNode);
+  return idNode;
+}
+

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -1,13 +1,24 @@
+#include <libxml/tree.h>
+#include "clang/Basic/Builtins.h"
+#include "clang/Lex/Lexer.h"
+#include "llvm/Support/Casting.h"
+#include "XMLVisitorBase.h"
+#include "ClangOperator.h"
+#include "ClangUtil.h"
+#include "TypeTableInfo.h"
 #include "XcodeMlNameElem.h"
+
+using namespace clang;
+using namespace llvm;
 
 xmlNodePtr
 makeNameNode(
-    TypeTableInfo&,
+    TypeTableInfo& TTI,
     const NamedDecl* ND)
 {
   xmlNodePtr node = nullptr;
   if (auto MD = dyn_cast<CXXMethodDecl>(ND)) {
-    node = makeNameNodeForCXXMethodDecl(MD);
+    node = makeNameNodeForCXXMethodDecl(TTI, MD);
   } else {
     node = xmlNewNode(nullptr, BAD_CAST "name");
     xmlNodeSetContent(node, BAD_CAST (ND->getNameAsString().c_str()));
@@ -19,12 +30,12 @@ makeNameNode(
     xmlNewProp(
         node,
         BAD_CAST "linkage",
-        stringifyLinkage(FL));
+        BAD_CAST stringifyLinkage(FL));
     if (FL != LI) {
       xmlNewProp(
           node,
           BAD_CAST "clang_linkage_internal",
-          stringifyLinkage(LI));
+          BAD_CAST stringifyLinkage(LI));
     }
   } else {
     // should not be executed

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -31,6 +31,19 @@ getNameKind(const NamedDecl* ND) {
   return "name";
 }
 
+xmlNodePtr
+makeIdNode(
+    TypeTableInfo& TTI,
+    const ValueDecl* VD)
+{
+  auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
+  xmlNewProp(
+      idNode,
+      BAD_CAST "type",
+      BAD_CAST TTI.getTypeName(VD->getType()).c_str());
+  return idNode;
+}
+
 } // namespace
 
 xmlNodePtr

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -141,15 +141,8 @@ makeIdNodeForFieldDecl(
      * Some field does not have name.
      *  Example: `struct A { int : 0; }; // unnamed bit field`
      */
-    auto nameNode = xmlNewChild(
-        idNode,
-        nullptr,
-        BAD_CAST "name",
-        BAD_CAST fieldName->getName().data());
-    xmlNewProp(
-        nameNode,
-        BAD_CAST "name_kind",
-        BAD_CAST "name");
+    auto nameNode = makeNameNode(TTI, field);
+    xmlAddChild(idNode, nameNode);
   }
   return idNode;
 }

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -140,29 +140,3 @@ makeIdNodeForFieldDecl(
   }
   return idNode;
 }
-
-xmlNodePtr
-makeFunctionTypeParamsNode(
-    TypeTableInfo& TTI,
-    const clang::FunctionProtoType* FTP)
-{
-  auto paramsNode = xmlNewNode(nullptr, BAD_CAST "params");
-  for (auto& paramT : FTP->getParamTypes()) {
-    auto paramNode = xmlNewNode(nullptr, BAD_CAST "name");
-      // FIXME: Add content (parameter name) to <name> element
-    xmlNewProp(
-        paramNode,
-        BAD_CAST "type",
-        BAD_CAST TTI.getTypeName(paramT).c_str());
-    xmlNewProp(
-        paramNode,
-        BAD_CAST "name_kind",
-        BAD_CAST "name");
-    xmlAddChild(paramsNode, paramNode);
-  }
-  if (FTP->isVariadic()) {
-    auto ellipNode = xmlNewNode(nullptr, BAD_CAST "ellipsis");
-    xmlAddChild(paramsNode, ellipNode);
-  }
-  return paramsNode;
-}

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -11,6 +11,28 @@
 using namespace clang;
 using namespace llvm;
 
+namespace {
+
+const char*
+getNameKind(const NamedDecl* ND) {
+  auto FD = dyn_cast<FunctionDecl>(ND);
+  if (!FD) {
+    return "name";
+  }
+  if (FD->isOverloadedOperator()) {
+    return "operator";
+  }
+  if (isa<CXXConstructorDecl>(FD)) {
+    return "constructor";
+  }
+  if (isa<CXXDestructorDecl>(FD)) {
+    return "destructor";
+  }
+  return "name";
+}
+
+} // namespace
+
 xmlNodePtr
 makeNameNode(
     TypeTableInfo& TTI,

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -127,4 +127,5 @@ makeIdNodeForFieldDecl(
         BAD_CAST "name_kind",
         BAD_CAST "name");
   }
+  return idNode;
 }

--- a/CXXtoXML/src/XcodeMlNameElem.h
+++ b/CXXtoXML/src/XcodeMlNameElem.h
@@ -1,0 +1,8 @@
+#ifndef XCODEMLNAMEELEM_H
+#define XCODEMLNAMEELEM_H
+
+xmlNodePtr makeNameNode(TypeTableInfo&, const NamedDecl*);
+xmlNodePtr makeNameNodeForCXXMethodDecl(TypeTableInfo&, const CXXMethodDecl*);
+xmlNodePtr makeIdNodeForCXXMethodDecl(TypeTableInfo&, const CXXMethodDecl*);
+
+#endif /*! XCODEMLNAMEELEM_H */

--- a/CXXtoXML/src/XcodeMlNameElem.h
+++ b/CXXtoXML/src/XcodeMlNameElem.h
@@ -1,8 +1,8 @@
 #ifndef XCODEMLNAMEELEM_H
 #define XCODEMLNAMEELEM_H
 
-xmlNodePtr makeNameNode(TypeTableInfo&, const NamedDecl*);
-xmlNodePtr makeNameNodeForCXXMethodDecl(TypeTableInfo&, const CXXMethodDecl*);
-xmlNodePtr makeIdNodeForCXXMethodDecl(TypeTableInfo&, const CXXMethodDecl*);
+xmlNodePtr makeNameNode(TypeTableInfo&, const clang::NamedDecl*);
+xmlNodePtr makeNameNodeForCXXMethodDecl(TypeTableInfo&, const clang::CXXMethodDecl*);
+xmlNodePtr makeIdNodeForCXXMethodDecl(TypeTableInfo&, const clang::CXXMethodDecl*);
 
 #endif /*! XCODEMLNAMEELEM_H */

--- a/CXXtoXML/src/XcodeMlNameElem.h
+++ b/CXXtoXML/src/XcodeMlNameElem.h
@@ -5,6 +5,5 @@ xmlNodePtr makeNameNode(TypeTableInfo&, const clang::NamedDecl*);
 xmlNodePtr makeNameNodeForCXXMethodDecl(TypeTableInfo&, const clang::CXXMethodDecl*);
 xmlNodePtr makeIdNodeForCXXMethodDecl(TypeTableInfo&, const clang::CXXMethodDecl*);
 xmlNodePtr makeIdNodeForFieldDecl(TypeTableInfo&, const clang::FieldDecl*);
-xmlNodePtr makeFunctionTypeParamsNode(TypeTableInfo&, const clang::FunctionProtoType*);
 
 #endif /*! XCODEMLNAMEELEM_H */

--- a/CXXtoXML/src/XcodeMlNameElem.h
+++ b/CXXtoXML/src/XcodeMlNameElem.h
@@ -4,5 +4,6 @@
 xmlNodePtr makeNameNode(TypeTableInfo&, const clang::NamedDecl*);
 xmlNodePtr makeNameNodeForCXXMethodDecl(TypeTableInfo&, const clang::CXXMethodDecl*);
 xmlNodePtr makeIdNodeForCXXMethodDecl(TypeTableInfo&, const clang::CXXMethodDecl*);
+xmlNodePtr makeIdNodeForFieldDecl(TypeTableInfo&, const clang::FieldDecl*);
 
 #endif /*! XCODEMLNAMEELEM_H */

--- a/CXXtoXML/src/XcodeMlNameElem.h
+++ b/CXXtoXML/src/XcodeMlNameElem.h
@@ -5,5 +5,6 @@ xmlNodePtr makeNameNode(TypeTableInfo&, const clang::NamedDecl*);
 xmlNodePtr makeNameNodeForCXXMethodDecl(TypeTableInfo&, const clang::CXXMethodDecl*);
 xmlNodePtr makeIdNodeForCXXMethodDecl(TypeTableInfo&, const clang::CXXMethodDecl*);
 xmlNodePtr makeIdNodeForFieldDecl(TypeTableInfo&, const clang::FieldDecl*);
+xmlNodePtr makeFunctionTypeParamsNode(TypeTableInfo&, const clang::FunctionProtoType*);
 
 #endif /*! XCODEMLNAMEELEM_H */


### PR DESCRIPTION
name要素を新しく作る処理がTypeTableInfoとDeclarationsVisitorとの間で重複していたので一個にまとめた。
今後name要素の仕様が変更されたときに困らないようにする。