### PR TITLE
Add more support for member function call

### DIFF
--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -332,11 +332,17 @@
       select="(@is_access_to_anon_record = '1')
               or (@is_access_to_anon_record = 'true')" />
     <xsl:variable
+      name="is_arrow"
+      select="(@is_arrow = '1')
+              or (@is_arrow = 'true')" />
+    <xsl:variable
       name="elemName"
       select="concat(substring('xcodemlAccessToAnonRecordExpr',
                                1 div $is_anon),
+                     substring('memberExpr',
+                               1 div (not($is_anon) and not($is_arrow))),
                      substring('memberRef',
-                               1 div not($is_anon)))"/>
+                               1 div (not($is_anon) and $is_arrow)))"/>
     <!-- "if ($is_anon)
          then ('xcodemlAccessToAnonRecordExpr')
          else ('memberRef')" -->
@@ -357,13 +363,11 @@
 
       <xsl:choose>
         <xsl:when test="$is_anon" />
-        <xsl:when test="@is_arrow = '1' or @is_arrow = 'true'">
+        <xsl:when test="$is_arrow">
           <xsl:apply-templates select="clangStmt" />
         </xsl:when>
         <xsl:otherwise>
-          <AddrOfExpr>
-            <xsl:apply-templates select="clangStmt" />
-          </AddrOfExpr>
+          <xsl:apply-templates select="clangStmt" />
         </xsl:otherwise>
       </xsl:choose>
     </xsl:element>

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -313,6 +313,15 @@
     </stringConstant>
   </xsl:template>
 
+  <xsl:template match="clangStmt[@class='CXXMemberCallExpr']">
+    <memberFunctionCall>
+      <xsl:apply-templates select="*[1]" />
+      <arguments>
+        <xsl:apply-templates select="*[position() &gt; 1]" />
+      </arguments>
+    </memberFunctionCall>
+  </xsl:template>
+
   <xsl:template match="clangStmt[@class='CXXThisExpr']">
     <thisExpr />
   </xsl:template>

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -42,20 +42,6 @@ DEFINE_CCH(callExprProc) {
   return (w["functionCall"])(w, node, src);
 }
 
-DEFINE_CCH(CXXMemberCallExprProc) {
-  auto funcNode = findFirst(node, "*[1]", src.ctxt);
-  const auto func = w.walk(funcNode, src);
-  const auto argNodes = findNodes(node, "*[position() > 1]", src.ctxt);
-  std::vector<CodeFragment> args;
-  for (auto a : argNodes) {
-    args.push_back(w.walk(a, src));
-  }
-  return func +
-    makeTokenNode("(") +
-    cxxgen::join(", ", args) +
-    makeTokenNode(")");
-}
-
 DEFINE_CCH(CXXCtorExprProc) {
   return makeTokenNode("(")
     + cxxgen::join(", ", w.walkChildren(node, src))
@@ -88,7 +74,6 @@ const ClangClassHandler ClangStmtHandler(
     {
       { "CallExpr", callExprProc },
       { "CXXConstructExpr", CXXCtorExprProc },
-      { "CXXMemberCallExpr", CXXMemberCallExprProc },
       { "CXXTemporaryObjectExpr", CXXTemporaryObjectExprProc },
     });
 

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -613,6 +613,20 @@ DEFINE_CB(varProc) {
   return makeNestedNameSpec(*nnsident, src) + name;
 }
 
+DEFINE_CB(memberExprProc) {
+  const auto baseName = getProp(node, "member");
+  const auto nnsident = getPropOrNull(node, "nns");
+  const auto name =
+    (nnsident.hasValue() ?
+        makeNestedNameSpec(*nnsident, src)
+      : makeVoidNode())
+    + makeTokenNode(baseName);
+  return
+    makeInnerNode(w.walkChildren(node, src))
+    + makeTokenNode(".")
+    + name;
+}
+
 DEFINE_CB(memberRefProc) {
   const auto baseName = getProp(node, "member");
   const auto nnsident = getPropOrNull(node, "nns");
@@ -990,6 +1004,7 @@ makeInnerNode,
   { "Var", varProc },
   { "varAddr", showNodeContent("(&", ")") },
   { "pointerRef", showUnaryOp("*") },
+  { "memberExpr", memberExprProc },
   { "memberRef", memberRefProc },
   { "memberAddr", memberAddrProc },
   { "memberPointerRef", memberPointerRefProc },

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -773,6 +773,12 @@ DEFINE_CB(functionCallProc) {
   return w.walk(function, src) + w.walk(arguments, src);
 }
 
+DEFINE_CB(memberFunctionCallProc) {
+  const auto function = findFirst(node, "*[1]", src.ctxt);
+  const auto arguments = findFirst(node, "arguments", src.ctxt);
+  return w.walk(function, src) + w.walk(arguments, src);
+}
+
 DEFINE_CB(argumentsProc) {
   auto acc = makeTokenNode("(");
   bool alreadyPrinted = false;
@@ -1039,6 +1045,7 @@ makeInnerNode,
   { "logNotExpr", showUnaryOp("!") },
   { "sizeOfExpr", showUnaryOp("sizeof") },
   { "functionCall", functionCallProc },
+  { "memberFunctionCall", memberFunctionCallProc },
   { "arguments", argumentsProc },
   { "condExpr", condExprProc },
   { "exprStatement", exprStatementProc },

--- a/XcodeMLtoCXX/src/Makefile
+++ b/XcodeMLtoCXX/src/Makefile
@@ -22,6 +22,7 @@ OBJS = XcodeMlType.o \
 	SymbolBuilder.o \
 	SymbolAnalyzer.o \
 	ClangClassHandler.o \
+	XcodeMlName.o \
 	XcodeMlNns.o
 
 $(XCODEMLTOCXX): $(OBJS)

--- a/XcodeMLtoCXX/src/XcodeMlName.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlName.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/Casting.h"
+#include "XcodeMlOperator.h"
 #include "StringTree.h"
 #include "XcodeMlType.h"
 #include "XcodeMlEnvironment.h"
@@ -63,8 +64,8 @@ OpFuncId::clone() const {
 
 CodeFragment
 OpFuncId::toString(const Environment&) const {
-  // FIXME
-  // return makeTokenNode("operator") + makeTokenNode(opName);
+  return makeTokenNode("operator")
+    + makeTokenNode(OperatorNameToSpelling(opName));
 }
 
 bool

--- a/XcodeMLtoCXX/src/XcodeMlName.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlName.cpp
@@ -1,19 +1,43 @@
+#include <map>
+#include <memory>
 #include <string>
+#include <vector>
+#include "llvm/ADT/Optional.h"
+#include "llvm/Support/Casting.h"
+#include "StringTree.h"
 #include "XcodeMlType.h"
 #include "XcodeMlNns.h"
 #include "XcodeMlName.h"
 
 namespace XcodeMl {
 
+UnqualId::UnqualId(UnqualIdKind k):
+  kind(k)
+{}
+
 UnqualId::~UnqualId() {
 }
 
-Ident::Ident(const std::string& id):
+UnqualIdKind
+UnqualId::getKind() const {
+  return kind;
+}
+
+UIDIdent::UIDIdent(const std::string& id):
   UnqualId(UnqualIdKind::Ident),
   ident(id)
 {}
 
-Ident::
+UnqualId*
+UIDIdent::clone() const {
+  auto copy = new UIDIdent(*this);
+  return copy;
+}
+
+bool
+UIDIdent::classof(const UnqualId* id) {
+  return id->getKind() == UnqualIdKind::Ident;
+}
 
 OpFuncId::OpFuncId(const std::string& op):
   UnqualId(UnqualIdKind::OpFuncId),
@@ -36,6 +60,7 @@ ConvFuncId::ConvFuncId(const DataTypeIdent& type):
   dtident(type)
 {}
 
+UnqualId*
 ConvFuncId::clone() const {
   auto copy = new ConvFuncId(*this);
   return copy;

--- a/XcodeMLtoCXX/src/XcodeMlName.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlName.cpp
@@ -1,0 +1,49 @@
+#include <string>
+#include "XcodeMlType.h"
+#include "XcodeMlNns.h"
+#include "XcodeMlName.h"
+
+namespace XcodeMl {
+
+UnqualId::~UnqualId() {
+}
+
+Ident::Ident(const std::string& id):
+  UnqualId(UnqualIdKind::Ident),
+  ident(id)
+{}
+
+Ident::
+
+OpFuncId::OpFuncId(const std::string& op):
+  UnqualId(UnqualIdKind::OpFuncId),
+  opName(op)
+{}
+
+UnqualId*
+OpFuncId::clone() const {
+  auto copy = new OpFuncId(*this);
+  return copy;
+}
+
+bool
+OpFuncId::classof(const UnqualId* id) {
+  return id->getKind() == UnqualIdKind::OpFuncId;
+}
+
+ConvFuncId::ConvFuncId(const DataTypeIdent& type):
+  UnqualId(UnqualIdKind::ConvFuncId),
+  dtident(type)
+{}
+
+ConvFuncId::clone() const {
+  auto copy = new ConvFuncId(*this);
+  return copy;
+}
+
+bool
+ConvFuncId::classof(const UnqualId* id) {
+  return id->getKind() == UnqualIdKind::ConvFuncId;
+}
+
+} // namespace XcodeMl

--- a/XcodeMLtoCXX/src/XcodeMlName.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlName.cpp
@@ -6,8 +6,14 @@
 #include "llvm/Support/Casting.h"
 #include "StringTree.h"
 #include "XcodeMlType.h"
+#include "XcodeMlEnvironment.h"
 #include "XcodeMlNns.h"
+
 #include "XcodeMlName.h"
+
+using XcodeMl::CodeFragment;
+using CXXCodeGen::makeTokenNode;
+using CXXCodeGen::makeVoidNode;
 
 namespace XcodeMl {
 
@@ -34,6 +40,11 @@ UIDIdent::clone() const {
   return copy;
 }
 
+CodeFragment
+UIDIdent::toString(const Environment&) const {
+  return makeTokenNode(ident);
+}
+
 bool
 UIDIdent::classof(const UnqualId* id) {
   return id->getKind() == UnqualIdKind::Ident;
@@ -50,6 +61,12 @@ OpFuncId::clone() const {
   return copy;
 }
 
+CodeFragment
+OpFuncId::toString(const Environment&) const {
+  // FIXME
+  // return makeTokenNode("operator") + makeTokenNode(opName);
+}
+
 bool
 OpFuncId::classof(const UnqualId* id) {
   return id->getKind() == UnqualIdKind::OpFuncId;
@@ -64,6 +81,13 @@ UnqualId*
 ConvFuncId::clone() const {
   auto copy = new ConvFuncId(*this);
   return copy;
+}
+
+CodeFragment
+ConvFuncId::toString(const Environment& env) const {
+  const auto T = env.at(dtident);
+  return makeTokenNode("operator")
+    + T->makeDeclaration(makeVoidNode(), env);
 }
 
 bool

--- a/XcodeMLtoCXX/src/XcodeMlName.h
+++ b/XcodeMLtoCXX/src/XcodeMlName.h
@@ -1,0 +1,49 @@
+#ifndef XCODEMLNAME_H
+#define XCODEMLNAME_H
+
+namespace XcodeMl {
+
+enum class UnqualIdKind {
+  Ident,
+  OpFuncId,
+  ConvFuncId,
+  Ctor,
+  Dtor,
+};
+
+class UnqualId {
+public:
+  UnqualId(UnqualIdKind);
+  virtual ~UnqualId() = 0;
+  virtual UnqualId* clone() const = 0;
+  UnqualIdKind getKind() const;
+protected:
+  UnqualId(const UnqualId&) = default;
+private:
+  UnqualIdKind kind;
+};
+
+class Name {
+private:
+  UnqualId id;
+  Nns nns;
+};
+
+class OpFuncId : public UnqualId {
+public:
+  OpFuncId(const std::string&);
+  ~OpFuncId() override = 0;
+  UnqualId* clone() const override;
+  static bool classof(const UnqualId*);
+private:
+  std::string opName;
+};
+
+class ConvFuncId : public UnqualId {
+public:
+  ConvFuncId(const std::string&);
+};
+
+} // namespace XcodeMl
+
+#endif /*! XCODEMLNAME_H */

--- a/XcodeMLtoCXX/src/XcodeMlName.h
+++ b/XcodeMLtoCXX/src/XcodeMlName.h
@@ -23,25 +23,49 @@ private:
   UnqualIdKind kind;
 };
 
+/**
+ * corresponds to the name elements in XcodeML, such as.
+ */
 class Name {
 private:
   UnqualId id;
   Nns nns;
 };
 
+class UIDIdent : public UnqualId {
+public:
+  UIDIdent(const std::string&);
+  ~UIDIdent() override = default;
+  UnqualId* clone() const override;
+  static bool classof(const UnqualId*);
+protected:
+  Ident(const Ident&) = default;
+private:
+  std::string ident;
+};
+
 class OpFuncId : public UnqualId {
 public:
   OpFuncId(const std::string&);
-  ~OpFuncId() override = 0;
+  ~OpFuncId() override = default;
   UnqualId* clone() const override;
   static bool classof(const UnqualId*);
+protected:
+  OpFuncId(const OpFuncId&) = default;
 private:
   std::string opName;
 };
 
 class ConvFuncId : public UnqualId {
 public:
-  ConvFuncId(const std::string&);
+  ConvFuncId(const DataTypeIdent&);
+  ~ConvFuncId() override = default;
+  UnqualId* clone() const override;
+  static bool classof(const UnqualId*);
+protected:
+  ConvFuncId(const ConvFuncId&) = default;
+private:
+  DataTypeIdent dtident;
 };
 
 } // namespace XcodeMl

--- a/XcodeMLtoCXX/src/XcodeMlName.h
+++ b/XcodeMLtoCXX/src/XcodeMlName.h
@@ -28,8 +28,8 @@ private:
  */
 class Name {
 private:
-  UnqualId id;
-  Nns nns;
+  std::shared_ptr<UnqualId> id;
+  std::shared_ptr<Nns> nns;
 };
 
 class UIDIdent : public UnqualId {
@@ -39,7 +39,7 @@ public:
   UnqualId* clone() const override;
   static bool classof(const UnqualId*);
 protected:
-  Ident(const Ident&) = default;
+  UIDIdent(const UIDIdent&) = default;
 private:
   std::string ident;
 };

--- a/XcodeMLtoCXX/src/XcodeMlName.h
+++ b/XcodeMLtoCXX/src/XcodeMlName.h
@@ -16,6 +16,7 @@ public:
   UnqualId(UnqualIdKind);
   virtual ~UnqualId() = 0;
   virtual UnqualId* clone() const = 0;
+  virtual CodeFragment toString(const Environment&) const = 0;
   UnqualIdKind getKind() const;
 protected:
   UnqualId(const UnqualId&) = default;
@@ -37,6 +38,7 @@ public:
   UIDIdent(const std::string&);
   ~UIDIdent() override = default;
   UnqualId* clone() const override;
+  CodeFragment toString(const Environment&) const override;
   static bool classof(const UnqualId*);
 protected:
   UIDIdent(const UIDIdent&) = default;
@@ -49,6 +51,7 @@ public:
   OpFuncId(const std::string&);
   ~OpFuncId() override = default;
   UnqualId* clone() const override;
+  CodeFragment toString(const Environment&) const override;
   static bool classof(const UnqualId*);
 protected:
   OpFuncId(const OpFuncId&) = default;
@@ -61,6 +64,7 @@ public:
   ConvFuncId(const DataTypeIdent&);
   ~ConvFuncId() override = default;
   UnqualId* clone() const override;
+  CodeFragment toString(const Environment&) const override;
   static bool classof(const UnqualId*);
 protected:
   ConvFuncId(const ConvFuncId&) = default;


### PR DESCRIPTION
* `memberFunctionCall` 要素を定義した
* `memberRef` 要素の代替として `memberExpr` 要素を定義した
* 逆変換でC++の名前を綺麗に扱うためのクラスとして `XcodeMl::UnqualId` とその派生クラス群を定義した (XcodeMLtoCXX/src/XcodeMlName.h)
* 正・逆変換を `memberFunctionCall`、`memberExpr` 要素に対応させた

メンバー関数としての演算子関数には対応していないが、これらの変更がmasterに取り込まれたあと別のブランチで対応する。