### PR TITLE
Redesign `memberExpr` & `functionCall`

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -123,8 +123,11 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
     if (const auto DRE = dyn_cast<clang::DeclRefExpr>(ME->getBase())) {
       const auto DN = DRE->getNameInfo().getName();
       newBoolProp("is_access_to_anon_record", DN.isEmpty());
-      auto nameNode = makeNameNode(*typetableinfo, DRE);
-      xmlAddChild(curNode, nameNode);
+
+      auto baseName = makeNameNode(*typetableinfo, DRE);
+      auto base = xmlNewNode(nullptr, BAD_CAST "base");
+      xmlAddChild(base, baseName);
+      xmlAddChild(curNode, base);
     }
   }
 

--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -122,9 +122,7 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
 
     const auto MD = ME->getMemberDecl();
     auto memberName = makeNameNode(*typetableinfo, MD);
-    auto member = xmlNewNode(nullptr, BAD_CAST "member");
-    xmlAddChild(member, memberName);
-    xmlAddChild(curNode, member);
+    xmlAddChild(curNode, memberName);
 
     if (const auto DRE = dyn_cast<clang::DeclRefExpr>(ME->getBase())) {
       const auto DN = DRE->getNameInfo().getName();

--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -120,6 +120,12 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
   if (auto ME = dyn_cast<clang::MemberExpr>(S)) {
     newBoolProp("is_arrow", ME->isArrow());
 
+    const auto MD = ME->getMemberDecl();
+    auto memberName = makeNameNode(*typetableinfo, MD);
+    auto member = xmlNewNode(nullptr, BAD_CAST "member");
+    xmlAddChild(member, memberName);
+    xmlAddChild(curNode, member);
+
     if (const auto DRE = dyn_cast<clang::DeclRefExpr>(ME->getBase())) {
       const auto DN = DRE->getNameInfo().getName();
       newBoolProp("is_access_to_anon_record", DN.isEmpty());

--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -129,11 +129,6 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
     if (const auto DRE = dyn_cast<clang::DeclRefExpr>(ME->getBase())) {
       const auto DN = DRE->getNameInfo().getName();
       newBoolProp("is_access_to_anon_record", DN.isEmpty());
-
-      auto baseName = makeNameNode(*typetableinfo, DRE);
-      auto base = xmlNewNode(nullptr, BAD_CAST "base");
-      xmlAddChild(base, baseName);
-      xmlAddChild(curNode, base);
     }
   }
 

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -399,7 +399,7 @@
          else ('memberRef')" -->
     <xsl:element name="{$elemName}">
       <xsl:apply-templates select="@*" />
-      <xsl:apply-templates select="name" />
+      <!-- lhs of member access (object) -->
       <xsl:choose>
         <xsl:when test="$is_anon" />
         <xsl:when test="$is_arrow">
@@ -409,6 +409,9 @@
           <xsl:apply-templates select="clangStmt" />
         </xsl:otherwise>
       </xsl:choose>
+
+      <!-- rhs of member access (name) -->
+      <xsl:apply-templates select="name" />
     </xsl:element>
   </xsl:template>
 

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -399,20 +399,16 @@
          else ('memberRef')" -->
     <xsl:element name="{$elemName}">
       <xsl:apply-templates select="@*" />
-      <member>
-        <xsl:apply-templates select="name" />
-      </member>
-      <object>
-        <xsl:choose>
-          <xsl:when test="$is_anon" />
-          <xsl:when test="$is_arrow">
-            <xsl:apply-templates select="clangStmt" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:apply-templates select="clangStmt" />
-          </xsl:otherwise>
-        </xsl:choose>
-      </object>
+      <xsl:apply-templates select="name" />
+      <xsl:choose>
+        <xsl:when test="$is_anon" />
+        <xsl:when test="$is_arrow">
+          <xsl:apply-templates select="clangStmt" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates select="clangStmt" />
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:element>
   </xsl:template>
 

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -399,28 +399,20 @@
          else ('memberRef')" -->
     <xsl:element name="{$elemName}">
       <xsl:apply-templates select="@*" />
-      <xsl:attribute name="member">
-        <xsl:value-of select="clangDeclarationNameInfo[@class='Identifier']" />
-      </xsl:attribute>
-      <xsl:if test="clangNestedNameSpecifier">
-        <!--
-             The second operand of member access is optionally qualified.
-             Example: `x.T::mem`, `x->T::mem`
-        -->
-        <xsl:attribute name="nns">
-          <xsl:value-of select="clangNestedNameSpecifier/@nns" />
-        </xsl:attribute>
-      </xsl:if>
-
-      <xsl:choose>
-        <xsl:when test="$is_anon" />
-        <xsl:when test="$is_arrow">
-          <xsl:apply-templates select="clangStmt" />
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:apply-templates select="clangStmt" />
-        </xsl:otherwise>
-      </xsl:choose>
+      <member>
+        <xsl:apply-templates select="name" />
+      </member>
+      <object>
+        <xsl:choose>
+          <xsl:when test="$is_anon" />
+          <xsl:when test="$is_arrow">
+            <xsl:apply-templates select="clangStmt" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates select="clangStmt" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </object>
     </xsl:element>
   </xsl:template>
 

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -363,12 +363,14 @@
   </xsl:template>
 
   <xsl:template match="clangStmt[@class='CXXMemberCallExpr']">
-    <memberFunctionCall>
-      <xsl:apply-templates select="*[1]" />
+    <functionCall>
+      <memberFunction>
+        <xsl:apply-templates select="clangStmt[1]" />
+      </memberFunction>
       <arguments>
-        <xsl:apply-templates select="*[position() &gt; 1]" />
+        <xsl:apply-templates select="clangStmt[position() &gt; 1]" />
       </arguments>
-    </memberFunctionCall>
+    </functionCall>
   </xsl:template>
 
   <xsl:template match="clangStmt[@class='CXXThisExpr']">

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -834,9 +834,10 @@ DEFINE_CB(exprStatementProc) {
 }
 
 DEFINE_CB(functionCallProc) {
-  xmlNodePtr function = findFirst(node, "function/*", src.ctxt);
+  xmlNodePtr function = findFirst(node, "function|memberFunction", src.ctxt);
+  const auto callee = findFirst(function, "*", src.ctxt);
   xmlNodePtr arguments = findFirst(node, "arguments", src.ctxt);
-  return w.walk(function, src) + w.walk(arguments, src);
+  return w.walk(callee, src) + w.walk(arguments, src);
 }
 
 DEFINE_CB(memberFunctionCallProc) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -668,15 +668,13 @@ DEFINE_CB(varProc) {
 }
 
 DEFINE_CB(memberExprProc) {
-  const auto baseName = getProp(node, "member");
-  const auto nnsident = getPropOrNull(node, "nns");
-  const auto name =
-    (nnsident.hasValue() ?
-        makeNestedNameSpec(*nnsident, src)
-      : makeVoidNode())
-    + makeTokenNode(baseName);
+  const auto expr = findFirst(node, "*", src.ctxt);
+  const auto name = getQualifiedNameFromNameNode(
+      findFirst(node, "*[2]", src.ctxt),
+      getPropOrNull(node, "type"),
+      src);
   return
-    makeInnerNode(w.walkChildren(node, src))
+    w.walk(expr, src)
     + makeTokenNode(".")
     + name;
 }

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -76,6 +76,22 @@ getDeclNameFromNameNode(
   return makeTokenNode("~") + (*className);
 }
 
+XcodeMl::CodeFragment
+getQualifiedNameFromNameNode(
+    xmlNodePtr nameNode,
+    const llvm::Optional<XcodeMl::DataTypeIdent>& dtident,
+    const SourceInfo& src)
+{
+  const auto name = getDeclNameFromNameNode(nameNode, dtident, src);
+  const auto ident = getPropOrNull(nameNode, "nns");
+  if (ident.hasValue()) {
+    const auto nns = src.nnsTable.at(*ident);
+    return nns->makeDeclaration(src.typeTable, src.nnsTable) + name;
+  } else {
+    return name;
+  }
+}
+
 } // namespace
 
 static XcodeMl::CodeFragment

--- a/XcodeMLtoCXX/src/LibXMLUtil.cpp
+++ b/XcodeMLtoCXX/src/LibXMLUtil.cpp
@@ -78,6 +78,11 @@ getContent(xmlNodePtr node) {
   return content;
 }
 
+std::string
+getName(xmlNodePtr node) {
+  return static_cast<XMLString>(node->name);
+}
+
 bool isTrueProp(xmlNodePtr node, const char* name, bool default_value) {
   if (!xmlHasProp(node, BAD_CAST name)) {
     return default_value;

--- a/XcodeMLtoCXX/src/LibXMLUtil.h
+++ b/XcodeMLtoCXX/src/LibXMLUtil.h
@@ -14,6 +14,7 @@ xmlNodePtr nth(xmlXPathObjectPtr obj, size_t n);
 std::string getProp(xmlNodePtr node, const std::string& attr);
 llvm::Optional<std::string> getPropOrNull(xmlNodePtr, const std::string&);
 std::string getContent(xmlNodePtr);
+std::string getName(xmlNodePtr);
 
 /* Utility for XcodeML */
 bool isTrueProp(xmlNodePtr node, const char* name, bool default_value);


### PR DESCRIPTION
`memberFunctionCall`要素 は廃止し、`memberFunction`要素をもつ`functionCall`要素で表現するようにした。
構文：
```
<functionCall>
  <memberFunction>
    memberExpr要素 (or memberPointerExpr要素)
  </memberFunction>
  <arguments>
    0個以上の式の要素
  </arguments>
</functionCall>
```

`memberExpr` 要素の構文を次のように変更した。
```
<memberExpr>
  式の要素
  名前の要素(<name> or <operator> or <conversion> or <constructor> or <destructor>)
</memberExpr>
```
以上の機能を正・逆変換に実装した。