### PR TITLE
Add support for `value` elements as aggregates

### DIFF
--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -354,9 +354,7 @@
 
   <xsl:template match="clangStmt[@class='InitListExpr']">
     <value>
-      <value>
-        <xsl:apply-templates />
-      </value>
+      <xsl:apply-templates />
     </value>
   </xsl:template>
 

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -320,6 +320,14 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="clangStmt[@class='InitListExpr']">
+    <value>
+      <value>
+        <xsl:apply-templates />
+      </value>
+    </value>
+  </xsl:template>
+
   <xsl:template match="clangStmt[@class='ImplicitCastExpr']">
     <implicitCastExpr>
       <xsl:apply-templates select="@*" />

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -81,15 +81,6 @@ DEFINE_CCH(CXXTemporaryObjectExprProc) {
     makeTokenNode(")");
 }
 
-DEFINE_CCH(initListExprProc) {
-  const auto children = findNodes(node, "*", src.ctxt);
-  std::vector<CodeFragment> elems;
-  for (auto&& child : children) {
-    elems.push_back(w.walk(child, src));
-  }
-  return wrapWithBrace(join(",", elems));
-}
-
 const ClangClassHandler ClangStmtHandler(
     "class",
     cxxgen::makeInnerNode,
@@ -99,7 +90,6 @@ const ClangClassHandler ClangStmtHandler(
       { "CXXConstructExpr", CXXCtorExprProc },
       { "CXXMemberCallExpr", CXXMemberCallExprProc },
       { "CXXTemporaryObjectExpr", CXXTemporaryObjectExprProc },
-      { "InitListExpr", initListExprProc },
     });
 
 DEFINE_CCH(FriendDeclProc) {

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -81,6 +81,15 @@ DEFINE_CCH(CXXTemporaryObjectExprProc) {
     makeTokenNode(")");
 }
 
+DEFINE_CCH(initListExprProc) {
+  const auto children = findNodes(node, "*", src.ctxt);
+  std::vector<CodeFragment> elems;
+  for (auto&& child : children) {
+    elems.push_back(w.walk(child, src));
+  }
+  return wrapWithBrace(join(",", elems));
+}
+
 const ClangClassHandler ClangStmtHandler(
     "class",
     cxxgen::makeInnerNode,
@@ -90,6 +99,7 @@ const ClangClassHandler ClangStmtHandler(
       { "CXXConstructExpr", CXXCtorExprProc },
       { "CXXMemberCallExpr", CXXMemberCallExprProc },
       { "CXXTemporaryObjectExpr", CXXTemporaryObjectExprProc },
+      { "InitListExpr", initListExprProc },
     });
 
 DEFINE_CCH(FriendDeclProc) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -860,6 +860,16 @@ DEFINE_CB(memberFunctionCallProc) {
   return w.walk(function, src) + w.walk(arguments, src);
 }
 
+DEFINE_CB(valueProc) {
+  const auto child = findFirst(node, "*", src.ctxt);
+  if (getName(child) == "value") {
+    // aggregate (See {#sec:program.value})
+    const auto grandchildren = w.walkChildren(child, src);
+    return wrapWithBrace(join(",", grandchildren));
+  }
+  return w.walk(child, src);
+}
+
 DEFINE_CB(newExprProc) {
   const auto type = src.typeTable.at(getProp(node, "type"));
   // FIXME: Support scalar type
@@ -1172,6 +1182,7 @@ makeInnerNode,
   { "exprStatement", exprStatementProc },
   { "returnStatement", returnStatementProc },
   { "varDecl", varDeclProc },
+  { "value", valueProc },
   { "usingDecl", usingDeclProc },
   { "classDecl", classDeclProc },
 

--- a/XcodeMLtoCXX/src/StringTree.cpp
+++ b/XcodeMLtoCXX/src/StringTree.cpp
@@ -171,6 +171,11 @@ wrapWithSquareBracket(const StringTreeRef& str) {
   return wrapWithStr("[", str, "]");
 }
 
+StringTreeRef
+wrapWithBrace(const StringTreeRef& str) {
+  return wrapWithStr("{", str, "}");
+}
+
 } // namespace CXXCodeGen
 
 CXXCodeGen::StringTreeRef operator+(

--- a/XcodeMLtoCXX/src/StringTree.h
+++ b/XcodeMLtoCXX/src/StringTree.h
@@ -71,6 +71,7 @@ StringTreeRef separateByBlankLines(const std::vector<StringTreeRef>&);
 StringTreeRef join(const std::string&, const std::vector<StringTreeRef>&);
 StringTreeRef wrapWithParen(const StringTreeRef&);
 StringTreeRef wrapWithSquareBracket(const StringTreeRef&);
+StringTreeRef wrapWithBrace(const StringTreeRef&);
 
 }
 


### PR DESCRIPTION
```
int a[3] = { 0, 1, 2 };
```
の `{ 0, 1, 2 }` などの式は `value` 要素で表現するが、これを正・逆変換に実装した。