### PR TITLE
Use `llvm-config --includedir` in Makefile

### DIFF
--- a/CXXtoXML/src/Makefile
+++ b/CXXtoXML/src/Makefile
@@ -1,9 +1,10 @@
 LLVM_CONFIG = /usr/local/bin/llvm-config
+LLVM_INCLUDE = /usr/local/include
 CXX = /usr/local/bin/clang++
 #LLVM_CONFIG = /usr/bin/llvm-config-3.6
 #CXX = /usr/bin/clang++-3.6
 CXXFLAGS = -O2 -g -Wall -Wextra -fno-rtti -std=c++11 -pedantic \
-	`pkg-config --cflags libxml-2.0` \
+	$(INCLUDE) \
 	-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
 
 USEDLIBS = -L$(shell $(LLVM_CONFIG) --libdir)
@@ -13,6 +14,9 @@ USEDLIBS += -lclangTooling -lclangFrontend -lclangSerialization -lclangDriver \
             -lclangFormat -lclangARCMigrate -lclangDynamicASTMatchers \
             -lclangIndex -lclangCodeGen -lclangFrontendTool \
             -lclangStaticAnalyzerCheckers -lclangRewrite -lclangRewriteFrontend
+INCLUDE = -I. \
+	  -I $(LLVM_INCLUDE) \
+	  `pkg-config --cflags libxml-2.0`
 USEDLIBS += $(shell $(LLVM_CONFIG) --libs mcparser bitreader support mc option)
 USEDLIBS += -lpthread -ldl -ltinfo -lz
 USEDLIBS += `pkg-config --libs libxml-2.0` -lclang

--- a/CXXtoXML/src/Makefile
+++ b/CXXtoXML/src/Makefile
@@ -1,5 +1,4 @@
 LLVM_CONFIG = /usr/local/bin/llvm-config
-LLVM_INCLUDE = /usr/local/include
 CXX = /usr/local/bin/clang++
 #LLVM_CONFIG = /usr/bin/llvm-config-3.6
 #CXX = /usr/bin/clang++-3.6
@@ -15,7 +14,7 @@ USEDLIBS += -lclangTooling -lclangFrontend -lclangSerialization -lclangDriver \
             -lclangIndex -lclangCodeGen -lclangFrontendTool \
             -lclangStaticAnalyzerCheckers -lclangRewrite -lclangRewriteFrontend
 INCLUDE = -I. \
-	  -I $(LLVM_INCLUDE) \
+	  -I $(shell $(LLVM_CONFIG) --includedir) \
 	  `pkg-config --cflags libxml-2.0`
 USEDLIBS += $(shell $(LLVM_CONFIG) --libs mcparser bitreader support mc option)
 USEDLIBS += -lpthread -ldl -ltinfo -lz

--- a/CXXtoXML/src/Makefile
+++ b/CXXtoXML/src/Makefile
@@ -15,10 +15,10 @@ USEDLIBS += -lclangTooling -lclangFrontend -lclangSerialization -lclangDriver \
             -lclangStaticAnalyzerCheckers -lclangRewrite -lclangRewriteFrontend
 INCLUDE = -I. \
 	  -I $(shell $(LLVM_CONFIG) --includedir) \
-	  `pkg-config --cflags libxml-2.0`
+	  $(shell pkg-config --cflags libxml-2.0)
 USEDLIBS += $(shell $(LLVM_CONFIG) --libs mcparser bitreader support mc option)
 USEDLIBS += -lpthread -ldl -ltinfo -lz
-USEDLIBS += `pkg-config --libs libxml-2.0` -lclang
+USEDLIBS += $(shell pkg-config --libs libxml-2.0) -lclang
 USEDLIBS += $(OTHERLIBS)
 
 RAVOBJS = XMLRAV.o


### PR DESCRIPTION
`make LLVM_INCLUDE=/path/to/include` でディレクトリを指定します。