### PR TITLE
Register `assignExpr` with opMap in XcodeMlOperator.cpp

### DIFF
--- a/XcodeMLtoCXX/src/XcodeMlOperator.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlOperator.cpp
@@ -16,6 +16,7 @@ opMap = {
   {"bitOrExpr", "|"},
   {"bitXorExpr", "^"},
 
+  {"assignExpr", "="},
   {"asgPlusExpr", "+="},
   {"asgMinusExpr", "-="},
   {"asgMulExpr", "*="},


### PR DESCRIPTION
Ref: [{#sec:expr.assign}](https://github.com/omni-compiler/ClangXcodeML/blob/b119953cf94f9430ef49292d9824f2df7b57448e/docs/XcodeML_CXX.md#assignexpr-%E8%A6%81%E7%B4%A0-secexprassign)