### PR TITLE
Add allocation/deallocation operators to XcodeMlOperator

### DIFF
--- a/XcodeMLtoCXX/src/XcodeMlOperator.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlOperator.cpp
@@ -35,6 +35,10 @@ opMap = {
   {"logLTExpr", "<"},
   {"logAndExpr", "&&"},
   {"logOrExpr", "||"},
+  {"newExpr", "new"},
+  {"newArrayExpr", "new[]"},
+  {"deleteExpr", "delete"},
+  {"deleteArrayExpr", "delete[]"},
 };
 
 namespace XcodeMl {


### PR DESCRIPTION
Update /XcodeMLtoCXX/src/XcodeMlOperator.cpp.

Add "newExpr", "newArrayExpr", "deleteExpr", "deleteArrayExpr" to `opMap`(`const std::map<std::string, std::string>`).