### PR TITLE
Revert "Remove an unnecessary command in CXXtoXcodeML"

### DIFF
--- a/scripts/CXXtoXcodeML
+++ b/scripts/CXXtoXcodeML
@@ -11,4 +11,5 @@ ${CXXTOXML} $@ |
       xsltproc ${XSLTsDIR}/add_symbols_elem.xsl -  |
       xsltproc ${XSLTsDIR}/add_globalsymbols_elem.xsl -  |
       xsltproc ${XSLTsDIR}/Program2XcodeProgram.xsl -  |
-      xsltproc ${XSLTsDIR}/handle_name_elem.xsl -
+      xsltproc ${XSLTsDIR}/handle_name_elem.xsl -  |
+      xmllint --format - 


### PR DESCRIPTION
This reverts commit e18fe52aee2e82d128edc35342fbd45a29959eea.

`xmllint --format` is better than `xsl:output/@indent`.