### PR TITLE
Don't use `std::move` on return value

### DIFF
--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -489,7 +489,7 @@ ClassSymbolsToSymbolEntry(const XcodeMl::ClassType* T) {
     std::tie(name, dtident) = member;
     entry[name] = dtident;
   }
-  return vec;
+  return entry;
 }
 
 XcodeMl::CodeFragment

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -475,7 +475,7 @@ getParams(xmlNodePtr fnNode, const SourceInfo& src) {
     XMLString name = xmlNodeGetContent(p);
     vec.push_back(makeTokenNode(name));
   }
-  return std::move(vec);
+  return vec;
 }
 
 SymbolEntry
@@ -489,7 +489,7 @@ ClassSymbolsToSymbolEntry(const XcodeMl::ClassType* T) {
     std::tie(name, dtident) = member;
     entry[name] = dtident;
   }
-  return std::move(entry);
+  return vec;
 }
 
 XcodeMl::CodeFragment


### PR DESCRIPTION
Fix CodeBuilder.cpp.

`std::move` suppress optimization (copy elision).