### PR TITLE
Remove unimportant functions

### DIFF
--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -96,15 +96,6 @@
 
   <xsl:template match="clangDecl[@class='Record']" />
 
-  <xsl:template match="clangDecl[@class='CXXRecord']">
-    <classDecl>
-      <xsl:apply-templates select="@*" />
-      <xsl:apply-templates
-        select="clangDecl[
-        not (@is_implicit = '1' or @is_implicit = 'true')]" />
-    </classDecl>
-  </xsl:template>
-
   <xsl:template match="clangDecl[@class='Field']">
     <varDecl>
       <xsl:apply-templates select="@*" />

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -63,37 +63,6 @@ getNns(const XcodeMl::NnsMap &nnsTable, xmlNodePtr nameNode) {
 }
 
 XcodeMl::CodeFragment
-getDeclNameFromNameNode(xmlNodePtr nameNode,
-    const llvm::Optional<XcodeMl::DataTypeIdent> &dtident,
-    const SourceInfo &src) {
-  const auto kind = getName(nameNode);
-  if (kind == "name") {
-    return makeTokenNode(getContent(nameNode));
-  } else if (kind == "operator") {
-    using namespace XcodeMl;
-    const auto op = makeOpNode(nameNode);
-    return makeTokenNode("operator") + op;
-  } else if (getName(nameNode) == "conversion") {
-    const auto dtident = getProp(nameNode, "destination_type");
-    const auto returnT = src.typeTable.at(dtident);
-    return makeTokenNode("operator")
-        + returnT->makeDeclaration(makeVoidNode(), src.typeTable);
-  }
-  assert(dtident.hasValue());
-  const auto T = src.typeTable[*dtident];
-  const auto classT = llvm::cast<XcodeMl::ClassType>(T.get());
-  const auto className = classT->name();
-  assert(className.hasValue());
-
-  if (kind == "constructor") {
-    return *className;
-  }
-
-  assert(kind == "destructor");
-  return makeTokenNode("~") + (*className);
-}
-
-XcodeMl::CodeFragment
 getQualifiedNameFromNameNode(xmlNodePtr nameNode,
     const llvm::Optional<XcodeMl::DataTypeIdent> &dtident,
     const SourceInfo &src) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -74,16 +74,6 @@ getQualifiedNameFromNameNode(xmlNodePtr nameNode,
   return (*nns)->makeDeclaration(src.typeTable, src.nnsTable) + name;
 }
 
-XcodeMl::CodeFragment
-getQualifiedNameFromTypedNode(xmlNodePtr node, const SourceInfo &src) {
-  const auto name = getDeclNameFromTypedNode(node, src);
-  auto nameNode = findFirst(node, "name", src.ctxt);
-  const auto nns = getNns(src.nnsTable, nameNode);
-  if (!nns.hasValue()) {
-    return name;
-  }
-  return (*nns)->makeDeclaration(src.typeTable, src.nnsTable) + name;
-}
 
 XcodeMl::CodeFragment
 wrapWithLangLink(const XcodeMl::CodeFragment &content, xmlNodePtr node) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -75,35 +75,6 @@ getQualifiedNameFromNameNode(xmlNodePtr nameNode,
 }
 
 XcodeMl::CodeFragment
-getDeclNameFromTypedNode(xmlNodePtr node, const SourceInfo &src) {
-  if (findFirst(node, "constructor", src.ctxt)) {
-    const auto classDtident = getProp(node, "parent_class");
-    const auto T = src.typeTable[classDtident];
-    const auto classT = llvm::cast<XcodeMl::ClassType>(T.get());
-    const auto name = classT->name();
-    assert(name.hasValue());
-    return *name;
-  } else if (findFirst(node, "destructor", src.ctxt)) {
-    const auto classDtident = getProp(node, "parent_class");
-    const auto T = src.typeTable[classDtident];
-    const auto classT = llvm::cast<XcodeMl::ClassType>(T.get());
-    const auto name = classT->name();
-    assert(name.hasValue());
-    return makeTokenNode("~") + (*name);
-  } else if (const auto opNode = findFirst(node, "operator", src.ctxt)) {
-    using namespace XcodeMl;
-    const auto op = makeOpNode(opNode);
-    return makeTokenNode("operator") + op;
-  } else if (const auto conv = findFirst(node, "conversion", src.ctxt)) {
-    const auto dtident = getProp(conv, "destination_type");
-    const auto returnT = src.typeTable.at(dtident);
-    return makeTokenNode("operator")
-        + returnT->makeDeclaration(makeVoidNode(), src.typeTable);
-  }
-  return makeTokenNode(getNameFromIdNode(node, src.ctxt));
-}
-
-XcodeMl::CodeFragment
 getQualifiedNameFromTypedNode(xmlNodePtr node, const SourceInfo &src) {
   const auto name = getDeclNameFromTypedNode(node, src);
   auto nameNode = findFirst(node, "name", src.ctxt);

--- a/scripts/CXXtoXcodeML
+++ b/scripts/CXXtoXcodeML
@@ -11,5 +11,4 @@ ${CXXTOXML} $@ |
       xsltproc ${XSLTsDIR}/add_symbols_elem.xsl -  |
       xsltproc ${XSLTsDIR}/add_globalsymbols_elem.xsl -  |
       xsltproc ${XSLTsDIR}/Program2XcodeProgram.xsl -  |
-      xsltproc ${XSLTsDIR}/handle_name_elem.xsl -  |
       xmllint --format - 


### PR DESCRIPTION
* handle_name_elem.xslをCXXtoXcodeMLから消した
* CodeBuilder.cppから取り除くべき関数を取り除いた
* Program2XcodeProgram.xslからクラス定義を出力するテンプレートを取り除いた

これをマージすることで一時的に逆変換が壊れます。以降のPRで直します。