### PR TITLE
Get parameter nodes from `TypeLoc/clangDecl[@class='ParmVar']`

### DIFF
--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -45,7 +45,7 @@
           <xsl:apply-templates select="@*" />
           <xsl:apply-templates select="name" />
 
-          <xsl:apply-templates select="params" />
+          <xsl:apply-templates select="TypeLoc" />
 
           <xsl:if test="@class='CXXConstructor'">
             <constructorInitializerList>

--- a/CXXtoXML/src/XSLTs/add_symbols_elem.xsl
+++ b/CXXtoXML/src/XSLTs/add_symbols_elem.xsl
@@ -37,31 +37,6 @@
     </clangStmt>
   </xsl:template>
 
-  <xsl:template match="clangDecl[@class='Function'
-      or @class='CXXMethod'
-      or @class='CXXConstructor'
-      or @class='CXXDestructor']">
-    <clangDecl>
-      <xsl:apply-templates select="@*" />
-
-      <params>
-        <xsl:for-each
-          select="TypeLoc[@class='FunctionProto']
-            /clangDecl[@class='ParmVar']">
-          <name>
-            <xsl:copy-of select="name/@*" />
-            <xsl:attribute name="type">
-              <xsl:value-of select="@xcodemlType" />
-            </xsl:attribute>
-            <xsl:value-of select="name" />
-          </name>
-        </xsl:for-each>
-      </params>
-
-      <xsl:apply-templates />
-    </clangDecl>
-  </xsl:template>
-
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -213,7 +213,8 @@ const CodeBuilder::Procedure handleScope = handleBracketsLn(
 std::vector<XcodeMl::CodeFragment>
 getParams(xmlNodePtr fnNode, const SourceInfo &src) {
   std::vector<XcodeMl::CodeFragment> vec;
-  const auto params = findNodes(fnNode, "params/name", src.ctxt);
+  const auto params =
+      findNodes(fnNode, "TypeLoc/clangDecl[@class='ParmVar']/name", src.ctxt);
   for (auto p : params) {
     XMLString name = xmlNodeGetContent(p);
     vec.push_back(makeTokenNode(name));


### PR DESCRIPTION
逆変換がXSLTの生成するparams要素の存在に依存していたので修正した。