### PR TITLE
Don't emit the return type of conversion functions

### DIFF
--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -230,7 +230,8 @@ makeFunctionDeclHead(XcodeMl::Function *func,
   const auto nameSpelling = name.toString(src.typeTable, src.nnsTable);
   const auto pUnqualId = name.getUnqualId();
   if (llvm::isa<XcodeMl::CtorName>(pUnqualId.get())
-      || llvm::isa<XcodeMl::DtorName>(pUnqualId.get())) {
+      || llvm::isa<XcodeMl::DtorName>(pUnqualId.get())
+      || llvm::isa<XcodeMl::ConvFuncId>(pUnqualId.get())) {
     return func->makeDeclarationWithoutReturnType(
         nameSpelling, args, src.typeTable);
   } else {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -232,6 +232,11 @@ makeFunctionDeclHead(XcodeMl::Function *func,
   if (llvm::isa<XcodeMl::CtorName>(pUnqualId.get())
       || llvm::isa<XcodeMl::DtorName>(pUnqualId.get())
       || llvm::isa<XcodeMl::ConvFuncId>(pUnqualId.get())) {
+    /* Do not emit return type
+     *    void A::A();
+     *    void A::~A();
+     *    int A::operator int();
+     */
     return func->makeDeclarationWithoutReturnType(
         nameSpelling, args, src.typeTable);
   } else {


### PR DESCRIPTION
変換関数の宣言には返り値型を書くことが出来ません。例: `int X::operator int();`