### PR TITLE
Traverse children of `InitListExpr` only once

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -195,6 +195,17 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
     newProp("stringLiteral", literalAsString.c_str());
   }
 
+  if (auto ILE = dyn_cast<InitListExpr>(S)) {
+    /* `InitListExpr` has two kinds of children, `SyntacticForm`
+     * and `SemanticForm`. Do not traverse `SyntacticForm`,
+     * otherwise it emits the elements twice.
+     */
+    for (Stmt::child_range range = ILE->children(); range; ++range) {
+      TraverseStmt(*range);
+    }
+    return false;
+  }
+
   UnaryExprOrTypeTraitExpr *UEOTTE = dyn_cast<UnaryExprOrTypeTraitExpr>(S);
   if (UEOTTE) {
     // 7.8 sizeof, alignof


### PR DESCRIPTION
`InitListExpr` has two kinds of children, `SyntacticForm` and
`SemanticForm`.

> // This method is called once for each pair of syntactic and semantic
> // InitListExpr, and it traverses the subtrees defined by the two forms. This
> // may cause some of the children to be visited twice, if they appear both in
> // the syntactic and the semantic form.
(/clang/include/clang/AST/RecursiveASTVisitor.h)

By default, `RecursiveASTVisitor` traverses both of them, therefore,
`DeclarationsVisitor` emits the elements of initializer lists twice.

Example:
    Input: `a[3] = { 1, 2, 3 };`
    Output: `a[3] = { 1, 2, 3, 1, 2, 3 };`

This commit solves the problem.
Update `DeclarationsVisitor::PreVisitStmt(S)`.
If `S` is an `InitListExpr`, then manually traverse the children of `S`
and return `false` to suppress the subsequent traverse.