### PR TITLE
Introduce `PKG_CFLAGS` and `PKG_LIBS` to Makefile

### DIFF
--- a/CXXtoXML/src/Makefile
+++ b/CXXtoXML/src/Makefile
@@ -15,11 +15,15 @@ USEDLIBS += -lclangTooling -lclangFrontend -lclangSerialization -lclangDriver \
             -lclangStaticAnalyzerCheckers -lclangRewrite -lclangRewriteFrontend
 INCLUDE = -I. \
 	  -I $(shell $(LLVM_CONFIG) --includedir) \
-	  $(shell pkg-config --cflags libxml-2.0)
+	  $(PKG_CFLAGS)
 USEDLIBS += $(shell $(LLVM_CONFIG) --libs mcparser bitreader support mc option)
 USEDLIBS += -lpthread -ldl -ltinfo -lz
-USEDLIBS += $(shell pkg-config --libs libxml-2.0) -lclang
+USEDLIBS += $(PKG_LIBS) \
+	    -lclang
 USEDLIBS += $(OTHERLIBS)
+
+PKG_CFLAGS = $(shell pkg-config --cflags libxml-2.0 2>/dev/null || echo -I/usr/include/libxml2)
+PKG_LIBS = $(shell pkg-config --libs libxml-2.0 2>/dev/null || echo -lxml2)
 
 RAVOBJS = XMLRAV.o
 OBJS =  CXXtoXML.o \

--- a/XcodeMLtoCXX/src/Makefile
+++ b/XcodeMLtoCXX/src/Makefile
@@ -1,12 +1,16 @@
 LLVM_CONFIG = /usr/local/bin/llvm-config
 CXX = /usr/local/bin/clang++
 CXXFLAGS = -O2 -g -Wall -Wextra -fno-rtti -std=c++11 -pedantic \
-	`pkg-config --cflags libxml-2.0` \
+	$(PKG_CFLAGS) \
 	-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS $(PCHFLAGS)
 
 USEDLIBS += -lpthread -ldl -ltinfo -lz
-USEDLIBS += `pkg-config --libs libxml-2.0`
+USEDLIBS += $(PKG_LIBS)
 USEDLIBS += $(OTHERLIBS)
+
+PKG_CFLAGS = $(shell pkg-config --cflags libxml-2.0 2>/dev/null || echo -I/usr/include/libxml2)
+PKG_LIBS = $(shell pkg-config --libs libxml-2.0 2>/dev/null || echo -lxml2)
+
 XCODEMLTOCXX = ../XcodeMLtoCXX
 
 OBJS = XcodeMlType.o \

--- a/XcodeMLtoCXX/tests/UnitTest/Makefile
+++ b/XcodeMLtoCXX/tests/UnitTest/Makefile
@@ -7,13 +7,16 @@ XCODEMLTOCXXSRCDIR = $(XCODEMLTOCXXDIR)/src
 LLVM_CONFIG = /usr/local/bin/llvm-config
 CXX = /usr/local/bin/clang++
 CXXFLAGS = -O2 -std=c++11 \
-	`pkg-config --cflags libxml-2.0` \
+	$(PKG_CFLAGS) \
 	-I$(XCODEMLTOCXXSRCDIR) \
 	-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS $(PCHFLAGS)
 
 USEDLIBS += -lpthread -ldl -ltinfo -lz
-USEDLIBS += `pkg-config --libs libxml-2.0`
+USEDLIBS += $(PKG_LIBS)
 USEDLIBS += $(OTHERLIBS)
+
+PKG_CFLAGS = $(shell pkg-config --cflags libxml-2.0 2>/dev/null || echo -I/usr/include/libxml2)
+PKG_LIBS = $(shell pkg-config --libs libxml-2.0 2>/dev/null || echo -lxml2)
 
 TARGETS = $(basename $(wildcard *.cpp))
 


### PR DESCRIPTION
Update /CXXtoXML/src/Makefile.
Update /XcodeMLtoCXX/src/Makefile.
Update /XcodeMLtoCXX/tests/UnitTest/Makefile.

Define `PKG_CFLAGS` and `PKG_LIBS`.
```
PKG_CFLAGS = $(shell pkg-config --cflags libxml-2.0 2>/dev/null || echo -I/usr/include/libxml2)
PKG_LIBS = $(shell pkg-config --libs libxml-2.0 2>/dev/null || echo -lxml2)
```
As a result, the test environments do not need `pkg-config`.