### PR TITLE
Fix wrong naming convention

### DIFF
--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -214,7 +214,7 @@ getParamNames(xmlNodePtr fnNode, const SourceInfo &src) {
 XcodeMl::CodeFragment
 makeFunctionDeclHead(XcodeMl::Function *func,
     const XcodeMl::Name &name,
-    const std::vector<XcodeMl::CodeFragment> &args,
+    const std::vector<XcodeMl::CodeFragment> &paramNames,
     const SourceInfo &src) {
   const auto nameSpelling = name.toString(src.typeTable, src.nnsTable);
   const auto pUnqualId = name.getUnqualId();
@@ -227,15 +227,15 @@ makeFunctionDeclHead(XcodeMl::Function *func,
      *    int A::operator int();
      */
     return func->makeDeclarationWithoutReturnType(
-        nameSpelling, args, src.typeTable);
+        nameSpelling, paramNames, src.typeTable);
   } else {
-    return func->makeDeclaration(nameSpelling, args, src.typeTable);
+    return func->makeDeclaration(nameSpelling, paramNames, src.typeTable);
   }
 }
 
 XcodeMl::CodeFragment
 makeFunctionDeclHead(xmlNodePtr node,
-    const std::vector<XcodeMl::CodeFragment> args,
+    const std::vector<XcodeMl::CodeFragment> paramNames,
     const SourceInfo &src) {
   const auto nameNode = findFirst(node, "name", src.ctxt);
   const auto name = getQualifiedNameFromNameNode(nameNode, src);
@@ -245,13 +245,13 @@ makeFunctionDeclHead(xmlNodePtr node,
   const auto fnType = llvm::cast<XcodeMl::Function>(T.get());
 
   auto acc = makeVoidNode();
-  acc = acc + makeFunctionDeclHead(fnType, name, args, src);
+  acc = acc + makeFunctionDeclHead(fnType, name, paramNames, src);
   return acc;
 }
 
 DEFINE_CB(functionDefinitionProc) {
-  const auto args = getParamNames(node, src);
-  auto acc = makeFunctionDeclHead(node, args, src);
+  const auto paramNames = getParamNames(node, src);
+  auto acc = makeFunctionDeclHead(node, paramNames, src);
 
   if (auto ctorInitList =
           findFirst(node, "constructorInitializerList", src.ctxt)) {
@@ -285,7 +285,7 @@ DEFINE_CB(varProc) {
 }
 
 DEFINE_CB(emitInlineMemberFunctionDefinition) {
-  const auto args = getParamNames(node, src);
+  const auto paramNames = getParamNames(node, src);
   auto acc = makeVoidNode();
   if (isTrueProp(node, "is_virtual", false)) {
     acc = acc + makeTokenNode("virtual");
@@ -293,7 +293,7 @@ DEFINE_CB(emitInlineMemberFunctionDefinition) {
   if (isTrueProp(node, "is_static", false)) {
     acc = acc + makeTokenNode("static");
   }
-  acc = acc + makeFunctionDeclHead(node, args, src);
+  acc = acc + makeFunctionDeclHead(node, paramNames, src);
 
   if (auto ctorInitList =
           findFirst(node, "constructorInitializerList", src.ctxt)) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -200,7 +200,7 @@ const CodeBuilder::Procedure handleScope = handleBracketsLn(
     "{", "}", handleIndentation(walkChildrenWithInsertingNewLines));
 
 std::vector<XcodeMl::CodeFragment>
-getParams(xmlNodePtr fnNode, const SourceInfo &src) {
+getParamNames(xmlNodePtr fnNode, const SourceInfo &src) {
   std::vector<XcodeMl::CodeFragment> vec;
   const auto params =
       findNodes(fnNode, "TypeLoc/clangDecl[@class='ParmVar']/name", src.ctxt);
@@ -250,7 +250,7 @@ makeFunctionDeclHead(xmlNodePtr node,
 }
 
 DEFINE_CB(functionDefinitionProc) {
-  const auto args = getParams(node, src);
+  const auto args = getParamNames(node, src);
   auto acc = makeFunctionDeclHead(node, args, src);
 
   if (auto ctorInitList =
@@ -285,7 +285,7 @@ DEFINE_CB(varProc) {
 }
 
 DEFINE_CB(emitInlineMemberFunctionDefinition) {
-  const auto args = getParams(node, src);
+  const auto args = getParamNames(node, src);
   auto acc = makeVoidNode();
   if (isTrueProp(node, "is_virtual", false)) {
     acc = acc + makeTokenNode("virtual");

--- a/XcodeMLtoCXX/src/TypeAnalyzer.cpp
+++ b/XcodeMLtoCXX/src/TypeAnalyzer.cpp
@@ -69,8 +69,8 @@ DEFINE_TA(pointerTypeProc) {
 }
 
 DEFINE_TA(functionTypeProc) {
-  XMLString returnName = xmlGetProp(node, BAD_CAST "return_type");
-  auto returnType = map[returnName];
+  const auto returnDTI = getProp(node, "return_type");
+  const auto returnType = map[returnDTI];
   xmlXPathObjectPtr paramsNode =
       xmlXPathNodeEval(node, BAD_CAST "params/paramTypeName", ctxt);
   std::vector<XcodeMl::DataTypeIdent> paramTypes;
@@ -82,8 +82,8 @@ DEFINE_TA(functionTypeProc) {
   const auto dtident = getProp(node, "type");
   map.setReturnType(dtident, returnType);
   const auto func = findFirst(node, "params/ellipsis", ctxt)
-      ? XcodeMl::makeVariadicFunctionType(dtident, returnName, paramTypes)
-      : XcodeMl::makeFunctionType(dtident, returnName, paramTypes);
+      ? XcodeMl::makeVariadicFunctionType(dtident, returnDTI, paramTypes)
+      : XcodeMl::makeFunctionType(dtident, returnDTI, paramTypes);
   func->setConst(isTrueProp(node, "is_const", false));
   func->setVolatile(isTrueProp(node, "is_volatile", false));
   map[dtident] = func;

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -280,11 +280,11 @@ ParamList::makeDeclaration(const std::vector<CodeFragment> &paramNames,
 }
 
 Function::Function(DataTypeIdent ident,
-    TypeRef r,
+    const DataTypeIdent &r,
     const std::vector<DataTypeIdent> &p,
     bool v)
     : Type(TypeKind::Function, ident),
-      returnValue(r->dataTypeIdent()),
+      returnValue(r),
       params(p, v),
       defaultArgs(p.size(), makeVoidNode()) {
 }

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -765,14 +765,6 @@ makeLValueReferenceType(const DataTypeIdent &ident, const DataTypeIdent &ref) {
 }
 
 TypeRef
-makeFunctionType(DataTypeIdent ident,
-    TypeRef returnType,
-    const Function::Params &params,
-    bool isVariadic) {
-  return std::make_shared<Function>(ident, returnType, params, isVariadic);
-}
-
-TypeRef
 makeArrayType(DataTypeIdent ident, TypeRef elemType, size_t size) {
   return std::make_shared<Array>(ident, elemType->dataTypeIdent(), size);
 }

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -289,19 +289,6 @@ Function::Function(DataTypeIdent ident,
       defaultArgs(p.size(), makeVoidNode()) {
 }
 
-Function::Function(DataTypeIdent ident, TypeRef r, const Params &p, bool v)
-    : Type(TypeKind::Function, ident),
-      returnValue(r->dataTypeIdent()),
-      params(),
-      defaultArgs() {
-  std::vector<DataTypeIdent> dtidents;
-  for (auto param : p) {
-    dtidents.push_back(std::get<0>(param));
-    defaultArgs.push_back(std::get<1>(param));
-  }
-  params = ParamList(dtidents, v);
-}
-
 CodeFragment
 Function::makeDeclarationWithoutReturnType(CodeFragment var,
     const std::vector<CodeFragment> &args,

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -772,6 +772,13 @@ makeArrayType(DataTypeIdent ident, DataTypeIdent elemName, Array::Size size) {
 }
 
 TypeRef
+makeFunctionType(const DataTypeIdent &ident,
+    const DataTypeIdent &returnType,
+    const std::vector<DataTypeIdent> &paramTypes) {
+  return std::make_shared<Function>(ident, returnType, paramTypes);
+}
+
+TypeRef
 makeEnumType(const DataTypeIdent &ident) {
   return std::make_shared<EnumType>(ident, EnumType::EnumName());
 }

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -779,6 +779,13 @@ makeFunctionType(const DataTypeIdent &ident,
 }
 
 TypeRef
+makeVariadicFunctionType(const DataTypeIdent &ident,
+    const DataTypeIdent &returnType,
+    const std::vector<DataTypeIdent> &paramTypes) {
+  return std::make_shared<Function>(ident, returnType, paramTypes, true);
+}
+
+TypeRef
 makeEnumType(const DataTypeIdent &ident) {
   return std::make_shared<EnumType>(ident, EnumType::EnumName());
 }

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -247,8 +247,9 @@ LValueReferenceType::classof(const Type *T) {
   return T->getKind() == TypeKind::LValueReference;
 }
 
-ParamList::ParamList(const std::vector<DataTypeIdent> &d, bool e)
-    : dtidents(d), hasEllipsis(e) {
+ParamList::ParamList(
+    const std::vector<DataTypeIdent> &paramTypes, bool ellipsis)
+    : dtidents(paramTypes), hasEllipsis(ellipsis) {
 }
 
 bool

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -266,12 +266,13 @@ ParamList::isEmpty() const {
 }
 
 CodeFragment
-ParamList::makeDeclaration(
-    const std::vector<CodeFragment> &vars, const Environment &env) const {
-  assert(dtidents.size() == vars.size());
+ParamList::makeDeclaration(const std::vector<CodeFragment> &paramNames,
+    const Environment &typeTable) const {
+  assert(dtidents.size() == paramNames.size());
   std::vector<CodeFragment> decls;
   for (int i = 0, len = dtidents.size(); i < len; ++i) {
-    decls.push_back(makeDecl(env[dtidents[i]], vars[i], env));
+    const auto ithType = typeTable.at(dtidents[i]);
+    decls.push_back(makeDecl(ithType, paramNames[i], typeTable));
   }
   return CXXCodeGen::join(",", decls)
       + (isVariadic() ? makeTokenNode(",") + makeTokenNode("...")

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -178,7 +178,7 @@ private:
 class Function : public Type {
 public:
   Function(DataTypeIdent,
-      TypeRef,
+      const DataTypeIdent &,
       const std::vector<DataTypeIdent> &,
       bool = false);
   CodeFragment makeDeclarationWithoutReturnType(

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -164,7 +164,7 @@ class ParamList {
 public:
   ParamList() = default;
   ParamList &operator=(const ParamList &) = default;
-  ParamList(const std::vector<DataTypeIdent> &, bool);
+  ParamList(const std::vector<DataTypeIdent> &paramTypes, bool ellipsis);
   bool isVariadic() const;
   bool isEmpty() const;
   CodeFragment makeDeclaration(

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -368,8 +368,6 @@ TypeRef makeQualifiedType(
 TypeRef makePointerType(DataTypeIdent, TypeRef);
 TypeRef makePointerType(DataTypeIdent, DataTypeIdent);
 TypeRef makeLValueReferenceType(const DataTypeIdent &, const DataTypeIdent &);
-TypeRef makeFunctionType(
-    DataTypeIdent, TypeRef, const Function::Params &, bool = false);
 TypeRef makeArrayType(DataTypeIdent, TypeRef, size_t);
 TypeRef makeArrayType(DataTypeIdent, TypeRef, size_t);
 TypeRef makeArrayType(DataTypeIdent, TypeRef, Array::Size);

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -167,8 +167,8 @@ public:
   ParamList(const std::vector<DataTypeIdent> &paramTypes, bool ellipsis);
   bool isVariadic() const;
   bool isEmpty() const;
-  CodeFragment makeDeclaration(
-      const std::vector<CodeFragment> &, const Environment &) const;
+  CodeFragment makeDeclaration(const std::vector<CodeFragment> &paramNames,
+      const Environment &typeTable) const;
 
 private:
   std::vector<DataTypeIdent> dtidents;

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -182,7 +182,6 @@ public:
       TypeRef,
       const std::vector<DataTypeIdent> &,
       bool = false);
-  Function(DataTypeIdent, TypeRef, const Params &, bool = false);
   CodeFragment makeDeclarationWithoutReturnType(
       CodeFragment, const std::vector<CodeFragment> &, const Environment &);
   CodeFragment makeDeclarationWithoutReturnType(

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -381,6 +381,9 @@ TypeRef makeFunctionType(const DataTypeIdent &ident,
     const std::vector<DataTypeIdent> &paramTypes);
 TypeRef makeStructType(
     const DataTypeIdent &, const CodeFragment &, const Struct::MemberList &);
+TypeRef makeVariadicFunctionType(const DataTypeIdent &ident,
+    const DataTypeIdent &returnType,
+    const std::vector<DataTypeIdent> &paramTypes);
 TypeRef makeOtherType(const DataTypeIdent &);
 
 bool hasParen(const TypeRef &, const Environment &);

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -376,6 +376,9 @@ TypeRef makeClassType(const DataTypeIdent &, const ClassType::Symbols &);
 TypeRef makeClassType(const DataTypeIdent &,
     const std::vector<ClassType::BaseClass> &,
     const ClassType::Symbols &);
+TypeRef makeFunctionType(const DataTypeIdent &ident,
+    const DataTypeIdent &returnType,
+    const std::vector<DataTypeIdent> &paramTypes);
 TypeRef makeStructType(
     const DataTypeIdent &, const CodeFragment &, const Struct::MemberList &);
 TypeRef makeOtherType(const DataTypeIdent &);

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -177,7 +177,6 @@ private:
 
 class Function : public Type {
 public:
-  using Params = std::vector<std::tuple<DataTypeIdent, CodeFragment>>;
   Function(DataTypeIdent,
       TypeRef,
       const std::vector<DataTypeIdent> &,


### PR DESCRIPTION
関数宣言中のデフォルト実引数に対応するために、まず関数型を表現する `XcodeMl::Function` のまわりの悪い命名を直しました。