### PR TITLE
Reimplement `CXXCodeGen::Stream` by Pimpl

### DIFF
--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -1,6 +1,5 @@
 #include <algorithm>
 #include <functional>
-#include <sstream>
 #include <memory>
 #include <map>
 #include <cassert>

--- a/XcodeMLtoCXX/src/LibXMLUtil.cpp
+++ b/XcodeMLtoCXX/src/LibXMLUtil.cpp
@@ -4,7 +4,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <sstream>
 #include <stdexcept>
 #include <vector>
 #include <libxml/debugXML.h>

--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -57,6 +57,12 @@ emit(StreamImpl &impl, const std::string &str) {
 Stream::Stream() : pimpl(make_unique<StreamImpl>()) {
 }
 
+Stream::~Stream() = default;
+
+Stream::Stream(Stream &&) = default;
+
+Stream &Stream::operator=(Stream &&) = default;
+
 std::string
 Stream::str() {
   return ss.str();

--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -1,8 +1,19 @@
 #include <cassert>
+#include <memory>
 #include <sstream>
 #include <string>
 
 #include "Stream.h"
+
+namespace {
+
+template <typename T, typename... Ts>
+std::unique_ptr<T>
+make_unique(Ts &&... params) {
+  return std::unique_ptr<T>(new T(std::forward<Ts>(params)...));
+}
+
+} // namespace
 
 namespace CXXCodeGen {
 

--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -54,7 +54,7 @@ emit(StreamImpl &impl, const std::string &str) {
 
 } // namespace
 
-Stream::Stream() : ss(), curIndent(0), alreadyIndented(false), lastChar('\n') {
+Stream::Stream() : pimpl(make_unique<StreamImpl>()) {
 }
 
 std::string

--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -21,6 +21,16 @@ const space_t space = {};
 
 const newline_t newline = {};
 
+struct StreamImpl {
+  StreamImpl() : ss(), curIndent(0), alreadyIndented(false), lastChar('\n') {
+  }
+
+  std::stringstream ss;
+  size_t curIndent;
+  bool alreadyIndented;
+  char lastChar;
+};
+
 Stream::Stream() : ss(), curIndent(0), alreadyIndented(false), lastChar('\n') {
 }
 

--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -65,32 +65,32 @@ Stream &Stream::operator=(Stream &&) = default;
 
 std::string
 Stream::str() {
-  return ss.str();
+  return pimpl->ss.str();
 }
 
 void
 Stream::indent(size_t amount) {
-  curIndent += amount;
+  pimpl->curIndent += amount;
 }
 
 void
 Stream::unindent(size_t amount) {
-  assert(curIndent >= amount);
-  curIndent -= amount;
+  assert(pimpl->curIndent >= amount);
+  pimpl->curIndent -= amount;
 }
 
 void
 Stream::insertSpace() {
   const std::string separators = "\n\t ";
-  if (separators.find(lastChar) == std::string::npos) {
-    emit(" ");
+  if (separators.find(pimpl->lastChar) == std::string::npos) {
+    emit(*pimpl, " ");
   }
 }
 
 void
 Stream::insertNewLine() {
-  emit("\n");
-  alreadyIndented = false;
+  emit(*pimpl, "\n");
+  pimpl->alreadyIndented = false;
 }
 
 namespace {
@@ -120,12 +120,12 @@ Stream::insert(const std::string &token) {
     return;
   }
 
-  outputIndentation();
+  outputIndentation(*pimpl);
 
-  if (shouldInterleaveSpace(lastChar, token[0])) {
-    emit(" ");
+  if (shouldInterleaveSpace(pimpl->lastChar, token[0])) {
+    emit(*pimpl, " ");
   }
-  emit(token);
+  emit(*pimpl, token);
 }
 
 } // namespace CXXCodeGen

--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -31,6 +31,29 @@ struct StreamImpl {
   char lastChar;
 };
 
+namespace {
+
+void
+outputIndentation(StreamImpl &impl) {
+  if (impl.alreadyIndented) {
+    return;
+  }
+  impl.ss << std::string(impl.curIndent, '\t');
+  impl.lastChar = '\t';
+  impl.alreadyIndented = true;
+}
+
+void
+emit(StreamImpl &impl, const std::string &str) {
+  if (str.empty()) {
+    return;
+  }
+  impl.ss << str;
+  impl.lastChar = str.back();
+}
+
+} // namespace
+
 Stream::Stream() : ss(), curIndent(0), alreadyIndented(false), lastChar('\n') {
 }
 
@@ -97,28 +120,6 @@ Stream::insert(const std::string &token) {
     emit(" ");
   }
   emit(token);
-}
-
-void
-Stream::outputIndentation() {
-  if (alreadyIndented) {
-    return;
-  }
-
-  for (size_t i = 0; i < curIndent; ++i) {
-    ss << "\t";
-  }
-  lastChar = '\t';
-  alreadyIndented = true;
-}
-
-void
-Stream::emit(const std::string &str) {
-  if (str.empty()) {
-    return;
-  }
-  ss << str;
-  lastChar = str.back();
 }
 
 } // namespace CXXCodeGen

--- a/XcodeMLtoCXX/src/Stream.h
+++ b/XcodeMLtoCXX/src/Stream.h
@@ -16,6 +16,9 @@ struct StreamImpl;
 class Stream {
 public:
   Stream();
+  ~Stream();
+  Stream(Stream &&);
+  Stream &operator=(Stream &&);
   std::string str();
   void indent(size_t);
   void insertNewLine();

--- a/XcodeMLtoCXX/src/Stream.h
+++ b/XcodeMLtoCXX/src/Stream.h
@@ -11,6 +11,8 @@ struct newline_t {};
 
 extern const newline_t newline;
 
+struct StreamImpl;
+
 class Stream {
 public:
   Stream();
@@ -22,13 +24,7 @@ public:
   void unindent(size_t);
 
 private:
-  void outputIndentation();
-  void emit(const std::string &);
-
-  std::stringstream ss;
-  size_t curIndent;
-  bool alreadyIndented;
-  char lastChar;
+  std::unique_ptr<StreamImpl> pimpl;
 };
 
 } // namespace CXXCodeGen

--- a/XcodeMLtoCXX/src/StringTree.cpp
+++ b/XcodeMLtoCXX/src/StringTree.cpp
@@ -1,5 +1,4 @@
 #include <memory>
-#include <sstream>
 #include <vector>
 
 #include "llvm/Support/Casting.h"

--- a/XcodeMLtoCXX/src/SymbolBuilder.cpp
+++ b/XcodeMLtoCXX/src/SymbolBuilder.cpp
@@ -1,5 +1,4 @@
 #include <functional>
-#include <sstream>
 #include <memory>
 #include <map>
 #include <cassert>

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <memory>
 #include <map>
-#include <sstream>
 #include <string>
 #include <vector>
 #include <libxml/tree.h>

--- a/XcodeMLtoCXX/tests/UnitTest/CXXCodeGenStream.cpp
+++ b/XcodeMLtoCXX/tests/UnitTest/CXXCodeGenStream.cpp
@@ -1,7 +1,6 @@
 #define BOOST_TEST_MODULE CXXCodeGen::Stream
 #include <boost/test/included/unit_test.hpp>
 #include <string>
-#include <sstream>
 #include <tuple>
 #include <utility>
 


### PR DESCRIPTION
`CXXCodeGen::Stream` はXcodeMLtoCXX/で定義されたクラスで、C++プログラムを実際に文字列として生成する役割を持つ。
今回 `#line` ディレクティブを実装することになったので、 `Stream` クラスにファイル名と行番号を記憶するためのメンバーを追加することにした。
ところで、このようなことは今後も起こりうる。つまり、C++プログラムをある決まった書式で出力したいという要望は今後も出てきそう。その場合 `CXXCodeGen::Stream` のデータメンバーが増えていくと考えられるので、クライアントの再コンパイルや `#include` の追加を防ぐために `Stream` クラスをPimplイディオムで書き直した。
細かい点についてはコミットメッセージを参照してください。