### PR TITLE
Search for `clangTypeLoc` instead of `TypeLoc`

### DIFF
--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -45,7 +45,7 @@
           <xsl:apply-templates select="@*" />
           <xsl:apply-templates select="name" />
 
-          <xsl:apply-templates select="TypeLoc" />
+          <xsl:apply-templates select="clangTypeLoc" />
 
           <xsl:if test="@class='CXXConstructor'">
             <constructorInitializerList>

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -160,7 +160,7 @@ const ClangClassHandler ClangStmtHandler("class",
     });
 
 DEFINE_CCH(FriendDeclProc) {
-  if (auto TL = findFirst(node, "TypeLoc", src.ctxt)) {
+  if (auto TL = findFirst(node, "clangTypeLoc", src.ctxt)) {
     /* friend class declaration */
     const auto dtident = getProp(TL, "type");
     const auto T = src.typeTable.at(dtident);

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -202,8 +202,8 @@ const CodeBuilder::Procedure handleScope = handleBracketsLn(
 std::vector<XcodeMl::CodeFragment>
 getParamNames(xmlNodePtr fnNode, const SourceInfo &src) {
   std::vector<XcodeMl::CodeFragment> vec;
-  const auto params =
-      findNodes(fnNode, "TypeLoc/clangDecl[@class='ParmVar']/name", src.ctxt);
+  const auto params = findNodes(
+      fnNode, "clangTypeLoc/clangDecl[@class='ParmVar']/name", src.ctxt);
   for (auto p : params) {
     XMLString name = xmlNodeGetContent(p);
     vec.push_back(makeTokenNode(name));


### PR DESCRIPTION
Update Program2XcodeProgram.xsl.
Update ClangClassHandler.cpp.
Update CodeBuilder.cpp.

The `TypeLoc` element was renamed to `clangTypeLoc` on the commit
7cf73588f03bc49522b7c163d3e02fab16faeb4f.
I forgot to update files that use this element.