### PR TITLE
Do not emit `Program` element

### DIFF
--- a/CXXtoXML/src/CXXtoXML.cpp
+++ b/CXXtoXML/src/CXXtoXML.cpp
@@ -65,7 +65,7 @@ public:
       clang::CompilerInstance &CI, StringRef Filename) override {
     (void)CI; // suppress warnings
     xmlDoc = xmlNewDoc(BAD_CAST "1.0");
-    xmlNodePtr rootnode = xmlNewNode(nullptr, BAD_CAST "Program");
+    xmlNodePtr rootnode = xmlNewNode(nullptr, BAD_CAST "clangAST");
     xmlDocSetRootElement(xmlDoc, rootnode);
 
     char strftimebuf[BUFSIZ];

--- a/CXXtoXML/src/CXXtoXML.cpp
+++ b/CXXtoXML/src/CXXtoXML.cpp
@@ -40,7 +40,7 @@ public:
     TypeTableInfo *TTI = &typetableinfo;
     NnsTableInfo nnstableinfo(MC, TTI);
     NnsTableInfo *NTI = &nnstableinfo;
-    DeclarationsVisitor DV(MC, rootNode, "clangAST", TTI, NTI);
+    DeclarationsVisitor DV(MC, rootNode, nullptr, TTI, NTI);
     Decl *D = CXT.getTranslationUnitDecl();
 
     DV.TraverseDecl(D);

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -29,10 +29,6 @@
     </globalDeclarations>
   </xsl:template>
 
-  <xsl:template match="clangAST">
-    <xsl:apply-templates />
-  </xsl:template>
-
   <xsl:template match="clangDecl[@class='Function'
       or @class='CXXMethod'
       or @class='CXXConversion'

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -4,7 +4,7 @@
     encoding="UTF-8"
     indent="yes"
     method="xml" />
-  <xsl:template match="Program">
+  <xsl:template match="clangAST">
     <XcodeProgram>
       <xsl:apply-templates />
     </XcodeProgram>
@@ -27,10 +27,6 @@
     <globalDeclarations>
       <xsl:apply-templates />
     </globalDeclarations>
-  </xsl:template>
-
-  <xsl:template match="clangAST">
-    <xsl:apply-templates />
   </xsl:template>
 
   <xsl:template match="clangDecl[@class='Function'

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -29,6 +29,10 @@
     </globalDeclarations>
   </xsl:template>
 
+  <xsl:template match="clangAST">
+    <xsl:apply-templates />
+  </xsl:template>
+
   <xsl:template match="clangDecl[@class='Function'
       or @class='CXXMethod'
       or @class='CXXConversion'

--- a/CXXtoXML/src/XSLTs/add_globalsymbols_elem.xsl
+++ b/CXXtoXML/src/XSLTs/add_globalsymbols_elem.xsl
@@ -124,6 +124,7 @@
       <typeTable>
         <xsl:apply-templates
             select="
+            clangAST/
             clangDecl[@class='TranslationUnit']/
             xcodemlTypeTable/*"/>
       </typeTable>
@@ -131,18 +132,19 @@
       <nnsTable>
         <xsl:apply-templates
             select="
+            clangAST/
             clangDecl[@class='TranslationUnit']/
             xcodemlNnsTable/*"/>
       </nnsTable>
 
       <globalSymbols>
         <xsl:for-each
-          select="clangDecl[@class='TranslationUnit']">
+          select="clangAST/clangDecl[@class='TranslationUnit']">
           <xsl:call-template name="emit-id-list-in-namespace"/>
         </xsl:for-each>
       </globalSymbols>
 
-      <xsl:apply-templates select="clangDecl" />
+      <xsl:apply-templates select="clangAST" />
 
     </Program>
   </xsl:template>

--- a/CXXtoXML/src/XSLTs/add_globalsymbols_elem.xsl
+++ b/CXXtoXML/src/XSLTs/add_globalsymbols_elem.xsl
@@ -124,7 +124,6 @@
       <typeTable>
         <xsl:apply-templates
             select="
-            clangAST/
             clangDecl[@class='TranslationUnit']/
             xcodemlTypeTable/*"/>
       </typeTable>
@@ -132,19 +131,18 @@
       <nnsTable>
         <xsl:apply-templates
             select="
-            clangAST/
             clangDecl[@class='TranslationUnit']/
             xcodemlNnsTable/*"/>
       </nnsTable>
 
       <globalSymbols>
         <xsl:for-each
-          select="clangAST/clangDecl[@class='TranslationUnit']">
+          select="clangDecl[@class='TranslationUnit']">
           <xsl:call-template name="emit-id-list-in-namespace"/>
         </xsl:for-each>
       </globalSymbols>
 
-      <xsl:apply-templates select="clangAST" />
+      <xsl:apply-templates select="clangDecl" />
 
     </Program>
   </xsl:template>

--- a/CXXtoXML/src/XSLTs/add_globalsymbols_elem.xsl
+++ b/CXXtoXML/src/XSLTs/add_globalsymbols_elem.xsl
@@ -117,14 +117,13 @@
     </xsl:for-each>
   </xsl:template>
 
-  <xsl:template match="/Program">
-    <Program>
+  <xsl:template match="/clangAST">
+    <clangAST>
       <xsl:apply-templates select="@*" />
 
       <typeTable>
         <xsl:apply-templates
             select="
-            clangAST/
             clangDecl[@class='TranslationUnit']/
             xcodemlTypeTable/*"/>
       </typeTable>
@@ -132,21 +131,20 @@
       <nnsTable>
         <xsl:apply-templates
             select="
-            clangAST/
             clangDecl[@class='TranslationUnit']/
             xcodemlNnsTable/*"/>
       </nnsTable>
 
       <globalSymbols>
         <xsl:for-each
-          select="clangAST/clangDecl[@class='TranslationUnit']">
+          select="clangDecl[@class='TranslationUnit']">
           <xsl:call-template name="emit-id-list-in-namespace"/>
         </xsl:for-each>
       </globalSymbols>
 
-      <xsl:apply-templates select="clangAST" />
+      <xsl:apply-templates select="clangDecl" />
 
-    </Program>
+    </clangAST>
   </xsl:template>
 
   <xsl:template match="xcodemlTypeTable" />

--- a/docs/ClangXML.md
+++ b/docs/ClangXML.md
@@ -11,22 +11,24 @@ ClangXML形式とは、C++プログラムをXMLで表現するための形式で
 ClangXML文書は次の構造に従う。
 
 `<Program>`  
-  `<clangDecl class="TranslationUnit">`  
-    `<xcodemlTypeTable>`  
-      _データ型定義要素_ ...  
-    `</xcodemlTypeTable>`  
-    `<xcodemlNnsTable>`  
-      _NNS定義要素_ ...  
-    `</xcodemlNnsTable>`  
-    _C++プログラムを表現する`clangDecl`要素_ ...  
-  `</clangDecl>`  
+  `<clangAST>`  
+    `<clangDecl class="TranslationUnit">`  
+      `<xcodemlTypeTable>`  
+        _データ型定義要素_ ...  
+      `</xcodemlTypeTable>`  
+      `<xcodemlNnsTable>`  
+        _NNS定義要素_ ...  
+      `</xcodemlNnsTable>`  
+      _C++プログラムを表現する`clangDecl`要素_ ...  
+    `</clangDecl>`  
+  `</clangAST>`  
 `</Program>`  
 
 ひとつのClangXML文書は、C++のひとつの翻訳単位をXML文書として表現する。
 
 ClangXML文書のルート要素は`Program`要素である。
-`Program`要素は、ただひとつの子要素として`clangDecl`要素をもつ。
-この`clangDecl`要素の`class`属性の値は`"TranslationUnit"`である。
+`Program`要素はただひとつの子要素として`clangAST`要素をもつ。
+`clangAST`要素はただひとつの子要素として`clangDecl`(`TranslationUnit`)要素をもつ。
 
 ClangXML文書は、
 C++プログラム中で使用される型(データ型)をデータ型識別名とデータ型定義要素によって表現する。
@@ -40,10 +42,16 @@ C++プログラム中で使用される型(データ型)をデータ型識別名
   `language=` `"C++"` | `"C"`  
   `time` `=` _時刻_  
   `>`  
-  _`clangDecl`要素_  
+  _`clangAST`要素_  
 `</Program>`  
 
 ClangXMLのルート要素は`Program`要素である。
+
+# `clangAST`要素
+
+`<clangAST>`  
+  _`clangDecl`要素_  
+`</clangAST>`  
 
 `clangDecl`要素の`class`属性の値は`"TranslationUnit"`でなければならない。
 

--- a/docs/ClangXML.md
+++ b/docs/ClangXML.md
@@ -11,24 +11,22 @@ ClangXML形式とは、C++プログラムをXMLで表現するための形式で
 ClangXML文書は次の構造に従う。
 
 `<Program>`  
-  `<clangAST>`  
-    `<clangDecl class="TranslationUnit">`  
-      `<xcodemlTypeTable>`  
-        _データ型定義要素_ ...  
-      `</xcodemlTypeTable>`  
-      `<xcodemlNnsTable>`  
-        _NNS定義要素_ ...  
-      `</xcodemlNnsTable>`  
-      _C++プログラムを表現する`clangDecl`要素_ ...  
-    `</clangDecl>`  
-  `</clangAST>`  
+  `<clangDecl class="TranslationUnit">`  
+    `<xcodemlTypeTable>`  
+      _データ型定義要素_ ...  
+    `</xcodemlTypeTable>`  
+    `<xcodemlNnsTable>`  
+      _NNS定義要素_ ...  
+    `</xcodemlNnsTable>`  
+    _C++プログラムを表現する`clangDecl`要素_ ...  
+  `</clangDecl>`  
 `</Program>`  
 
 ひとつのClangXML文書は、C++のひとつの翻訳単位をXML文書として表現する。
 
 ClangXML文書のルート要素は`Program`要素である。
-`Program`要素はただひとつの子要素として`clangAST`要素をもつ。
-`clangAST`要素はただひとつの子要素として`clangDecl`(`TranslationUnit`)要素をもつ。
+`Program`要素は、ただひとつの子要素として`clangDecl`要素をもつ。
+この`clangDecl`要素の`class`属性の値は`"TranslationUnit"`である。
 
 ClangXML文書は、
 C++プログラム中で使用される型(データ型)をデータ型識別名とデータ型定義要素によって表現する。
@@ -42,16 +40,10 @@ C++プログラム中で使用される型(データ型)をデータ型識別名
   `language=` `"C++"` | `"C"`  
   `time` `=` _時刻_  
   `>`  
-  _`clangAST`要素_  
+  _`clangDecl`要素_  
 `</Program>`  
 
 ClangXMLのルート要素は`Program`要素である。
-
-# `clangAST`要素
-
-`<clangAST>`  
-  _`clangDecl`要素_  
-`</clangAST>`  
 
 `clangDecl`要素の`class`属性の値は`"TranslationUnit"`でなければならない。
 


### PR DESCRIPTION
Update CXXtoXML.cpp.
Remove `clangAST`, an unnecessary wrapper element.

Pass `nullptr` instead of `"clangAST"` to the constructor of `XMLVisitorBase` as the `ChildName` parameter.

```
  explicit XMLVisitorBase(clang::MangleContext *MC,
      xmlNodePtr Parent,
      const char *ChildName,
      TypeTableInfo *TTI = nullptr,
      NnsTableInfo *NTI = nullptr)
      : XMLVisitorBaseImpl(MC,
            (ChildName ? xmlNewTextChild(
                             Parent, nullptr, BAD_CAST ChildName, nullptr)
                       : Parent),
            TTI,
            NTI),
        optContext(){};
```
([/CXXtoXML/src/XMLVisitorBase.h](https://github.com/omni-compiler/ClangXcodeML/blob/master/CXXtoXML/src/XMLVisitorBase.h#L65))