### PR TITLE
Preserve types of literals

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -146,9 +146,10 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
     const unsigned INIT_BUFFER_SIZE = 32;
     SmallVector<char, INIT_BUFFER_SIZE> buffer;
     const auto &CXT = mangleContext->getASTContext();
-    const auto location = CXT.getSourceManager().getSpellingLoc(IL->getLocation());
-    auto spelling = clang::Lexer::getSpelling(
-        location, buffer, CXT.getSourceManager(), CXT.getLangOpts());
+    const auto &SM = CXT.getSourceManager();
+    const auto location = SM.getSpellingLoc(IL->getLocation());
+    const auto spelling =
+        clang::Lexer::getSpelling(location, buffer, SM, CXT.getLangOpts());
     newProp("token", spelling.str().c_str());
     std::string decimalNotation = IL->getValue().toString(10, true);
     newProp("decimalNotation", decimalNotation.c_str());

--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -145,7 +145,7 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
   if (auto IL = dyn_cast<IntegerLiteral>(S)) {
     const unsigned INIT_BUFFER_SIZE = 32;
     SmallVector<char, INIT_BUFFER_SIZE> buffer;
-    auto &CXT = mangleContext->getASTContext();
+    const auto &CXT = mangleContext->getASTContext();
     const auto location = CXT.getSourceManager().getSpellingLoc(IL->getLocation());
     auto spelling = clang::Lexer::getSpelling(
         location, buffer, CXT.getSourceManager(), CXT.getLangOpts());

--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -146,8 +146,9 @@ DeclarationsVisitor::PreVisitStmt(Stmt *S) {
     const unsigned INIT_BUFFER_SIZE = 32;
     SmallVector<char, INIT_BUFFER_SIZE> buffer;
     auto &CXT = mangleContext->getASTContext();
+    const auto location = CXT.getSourceManager().getSpellingLoc(IL->getLocation());
     auto spelling = clang::Lexer::getSpelling(
-        IL->getLocation(), buffer, CXT.getSourceManager(), CXT.getLangOpts());
+        location, buffer, CXT.getSourceManager(), CXT.getLangOpts());
     newProp("token", spelling.str().c_str());
     std::string decimalNotation = IL->getValue().toString(10, true);
     newProp("decimalNotation", decimalNotation.c_str());

--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -359,27 +359,6 @@
     </castExpr>
   </xsl:template>
 
-  <xsl:template match="clangStmt[@class='CharacterLiteral']">
-    <intConstant>
-      <xsl:apply-templates select="@*" />
-      <xsl:value-of select="@hexadecimalNotation" />
-    </intConstant>
-  </xsl:template>
-
-  <xsl:template match="clangStmt[@class='IntegerLiteral']">
-    <intConstant>
-      <xsl:apply-templates select="@*" />
-      <xsl:value-of select="@decimalNotation" />
-    </intConstant>
-  </xsl:template>
-
-  <xsl:template match="clangStmt[@class='FloatingLiteral']">
-    <floatConstant>
-      <xsl:apply-templates select="@*" />
-      <xsl:value-of select="@token" />
-    </floatConstant>
-  </xsl:template>
-
   <xsl:template match="clangStmt[@class='StringLiteral']">
     <stringConstant>
       <xsl:apply-templates select="@*" />

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -58,6 +58,11 @@ DEFINE_CCH(CXXDeleteExprProc) {
   return makeTokenNode("delete") + w.walk(allocated, src);
 }
 
+DEFINE_CCH(emitTokenAttrValue) {
+  const auto token = getProp(node, "token");
+  return makeTokenNode(token);
+}
+
 XcodeMl::CodeFragment
 makeBases(const XcodeMl::ClassType &T, SourceInfo &src) {
   using namespace XcodeMl;
@@ -159,6 +164,8 @@ const ClangClassHandler ClangStmtHandler("class",
         std::make_tuple("CXXConstructExpr", CXXCtorExprProc),
         std::make_tuple("CXXDeleteExpr", CXXDeleteExprProc),
         std::make_tuple("CXXTemporaryObjectExpr", CXXTemporaryObjectExprProc),
+        std::make_tuple("IntegerLiteral", emitTokenAttrValue),
+        std::make_tuple("FloatingLiteral", emitTokenAttrValue),
     });
 
 DEFINE_CCH(FriendDeclProc) {

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -161,6 +161,7 @@ const ClangClassHandler ClangStmtHandler("class",
     {
         std::make_tuple("BreakStmt", BreakStmtProc),
         std::make_tuple("CallExpr", callExprProc),
+        std::make_tuple("CharacterLiteral", emitTokenAttrValue),
         std::make_tuple("CXXConstructExpr", CXXCtorExprProc),
         std::make_tuple("CXXDeleteExpr", CXXDeleteExprProc),
         std::make_tuple("CXXTemporaryObjectExpr", CXXTemporaryObjectExprProc),

--- a/tests/Compilability/define_constant.src.cpp
+++ b/tests/Compilability/define_constant.src.cpp
@@ -1,0 +1,6 @@
+#define NUM 42
+
+int
+main() {
+  int i = NUM + NUM;
+}

--- a/tests/Compilability/overload_int_char.src.cpp
+++ b/tests/Compilability/overload_int_char.src.cpp
@@ -1,0 +1,18 @@
+int
+func(int) {
+  return 100;
+}
+
+int
+func(char) {
+  return 200;
+}
+
+int
+main() {
+  char c = 'A';
+  if (func(c) != 200) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
* 正変換コアを更新して、 `clangStmt`要素の`token`属性が正しい値をもつようにした
* 整数リテラルの接尾辞をちゃんと保存して、リテラルの型が正変換→逆変換の過程で保たれるようにした。文字リテラルも同様
* Program2XcodeProgram.xslのテンプレートルールの数を減らした
* テストケースを追加した