### PR TITLE
Don't emit language linkage declarations if the source language is C

### DIFF
--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -6,6 +6,7 @@
     method="xml" />
   <xsl:template match="clangAST">
     <XcodeProgram>
+      <xsl:apply-templates select="@*" />
       <xsl:apply-templates />
     </XcodeProgram>
   </xsl:template>

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -880,6 +880,7 @@ buildCode(
       ctxt,
       parseTypeTable(typeTableNode, ctxt, ss),
       analyzeNnsTable(nnsTableNode, ctxt),
+      getSourceLanguage(rootNode, ctxt),
   };
 
   cxxgen::Stream out;

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -828,6 +828,29 @@ const CodeBuilder ProgramBuilder("ProgramBuilder",
         // Ignore Decl_Record (structs are already emitted)
     });
 
+namespace {
+
+Language
+getSourceLanguage(xmlNodePtr rootNode, xmlXPathContextPtr ctxt) {
+  const auto topNode = findFirst(rootNode, "/XcodeProgram", ctxt);
+
+  const auto lang = getPropOrNull(topNode, "language");
+  if (!lang.hasValue()) {
+    // The default value of `language` attribute is "C++"
+    return Language::CPlusPlus;
+  }
+
+  if (*lang == "C++") {
+    return Language::CPlusPlus;
+  } else if (*lang == "C") {
+    return Language::C;
+  } else {
+    return Language::Invalid;
+  }
+}
+
+} // namespace
+
 const CodeBuilder ClassDefinitionBuilder("ClassDefinitionBuilder",
     makeInnerNode,
     {

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -15,6 +15,7 @@ public:
   xmlXPathContextPtr ctxt;
   XcodeMl::Environment typeTable;
   XcodeMl::NnsMap nnsTable;
+  Language language;
 };
 
 #endif /* !SOURCEINFO_H */

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -1,6 +1,11 @@
 #ifndef SOURCEINFO_H
 #define SOURCEINFO_H
 
+enum class Language {
+  C,
+  CPlusPlus,
+};
+
 /*!
  * \brief A pack of necessary information for generating
  * C++ source code.

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -2,6 +2,7 @@
 #define SOURCEINFO_H
 
 enum class Language {
+  Invalid,
   C,
   CPlusPlus,
 };


### PR DESCRIPTION
逆変換を更新して, C++に対してのみ言語リンケージ宣言 `extern "C"`, `extern "C++"` を出力するようにした.