### PR TITLE
Add names to unnamed classes

### DIFF
--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -144,7 +144,7 @@ DEFINE_CCH(CXXRecordProc) {
   assert(classT);
 
   setClassName(*classT, node, src);
-  const auto nameSpelling = classT->name().getValueOr(cxxgen::makeVoidNode());
+  const auto nameSpelling = *(classT->name()); // now class name must exist
 
   if (isTrueProp(node, "is_this_declaration_a_definition", false)) {
     return emitClassDefinition(node, ClassDefinitionBuilder, src, *classT);

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -118,6 +118,19 @@ emitClassDefinition(xmlNodePtr node,
       + cxxgen::makeNewLineNode();
 }
 
+void
+setClassName(XcodeMl::ClassType &classType, xmlNodePtr node, SourceInfo &src) {
+  const auto nameNode = findFirst(node, "name", src.ctxt);
+  if (!nameNode || isEmpty(nameNode)) {
+    /* classType is unnamed */
+    classType.setName(src.getUniqueName());
+    return;
+  }
+  const auto className = getQualifiedNameFromNameNode(nameNode, src);
+  const auto nameSpelling = className.toString(src.typeTable, src.nnsTable);
+  classType.setName(nameSpelling);
+}
+
 DEFINE_CCH(CXXRecordProc) {
   if (isTrueProp(node, "is_implicit", false)) {
     return cxxgen::makeVoidNode();

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -118,6 +118,16 @@ emitClassDefinition(xmlNodePtr node,
       + cxxgen::makeNewLineNode();
 }
 
+namespace {
+
+bool
+isUnnamedClassDecl(xmlNodePtr node, const SourceInfo &src) {
+  const auto nameNode = findFirst(node, "name", src.ctxt);
+  return getContent(nameNode).empty();
+}
+
+} // namespace
+
 DEFINE_CCH(CXXRecordProc) {
   if (isTrueProp(node, "is_implicit", false)) {
     return cxxgen::makeVoidNode();

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -122,7 +122,10 @@ void
 setClassName(XcodeMl::ClassType &classType, xmlNodePtr node, SourceInfo &src) {
   const auto nameNode = findFirst(node, "name", src.ctxt);
   if (!nameNode || isEmpty(nameNode)) {
-    /* classType is unnamed */
+    /* `classType` is unnamed.
+     * Unnamed classes are problematic, so give a name to `classType`
+     * such as `__xcodeml_1`.
+     */
     classType.setName(src.getUniqueName());
     return;
   }

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -140,10 +140,8 @@ DEFINE_CCH(CXXRecordProc) {
   auto classT = llvm::dyn_cast<XcodeMl::ClassType>(T.get());
   assert(classT);
 
-  const auto nameNode = findFirst(node, "name", src.ctxt);
-  const auto className = getQualifiedNameFromNameNode(nameNode, src);
-  const auto nameSpelling = className.toString(src.typeTable, src.nnsTable);
-  classT->setName(nameSpelling);
+  setClassName(*classT, node, src);
+  const auto nameSpelling = classT->name().getValueOr(cxxgen::makeVoidNode());
 
   if (isTrueProp(node, "is_this_declaration_a_definition", false)) {
     return emitClassDefinition(node, ClassDefinitionBuilder, src, *classT);

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -610,9 +610,17 @@ DEFINE_CB(varDeclProc) {
   const auto type = src.typeTable.at(dtident);
 
   auto acc = makeVoidNode();
-  acc = acc + makeDecl(type,
-                  name.toString(src.typeTable, src.nnsTable),
-                  src.typeTable);
+  if (src.unnamedClassDecls.find(dtident) != src.unnamedClassDecls.end()) {
+    // unnamed class declaration: `class { } a;`
+    // The definition of unnamed class should have been appeared
+    acc = acc + src.unnamedClassDecls[dtident]
+        + name.toString(src.typeTable, src.nnsTable);
+  } else {
+    acc = acc + makeDecl(type,
+                    name.toString(src.typeTable, src.nnsTable),
+                    src.typeTable);
+  }
+
   xmlNodePtr valueElem = findFirst(node, "value", src.ctxt);
   if (!valueElem) {
     return wrapWithLangLink(acc + makeTokenNode(";"), node, src);

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -610,17 +610,9 @@ DEFINE_CB(varDeclProc) {
   const auto type = src.typeTable.at(dtident);
 
   auto acc = makeVoidNode();
-  if (src.unnamedClassDecls.find(dtident) != src.unnamedClassDecls.end()) {
-    // unnamed class declaration: `class { } a;`
-    // The definition of unnamed class should have been appeared
-    acc = acc + src.unnamedClassDecls[dtident]
-        + name.toString(src.typeTable, src.nnsTable);
-  } else {
-    acc = acc + makeDecl(type,
-                    name.toString(src.typeTable, src.nnsTable),
-                    src.typeTable);
-  }
-
+  acc = acc + makeDecl(type,
+                  name.toString(src.typeTable, src.nnsTable),
+                  src.typeTable);
   xmlNodePtr valueElem = findFirst(node, "value", src.ctxt);
   if (!valueElem) {
     return wrapWithLangLink(acc + makeTokenNode(";"), node, src);
@@ -894,7 +886,6 @@ buildCode(
       parseTypeTable(typeTableNode, ctxt, ss),
       analyzeNnsTable(nnsTableNode, ctxt),
       getSourceLanguage(rootNode, ctxt),
-      {},
   };
 
   cxxgen::Stream out;

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -881,12 +881,10 @@ buildCode(
       findFirst(rootNode, "/XcodeProgram/typeTable", ctxt);
   xmlNodePtr nnsTableNode =
       findFirst(rootNode, "/XcodeProgram/nnsTable", ctxt);
-  SourceInfo src = {
-      ctxt,
+  SourceInfo src(ctxt,
       parseTypeTable(typeTableNode, ctxt, ss),
       analyzeNnsTable(nnsTableNode, ctxt),
-      getSourceLanguage(rootNode, ctxt),
-  };
+      getSourceLanguage(rootNode, ctxt));
 
   cxxgen::Stream out;
   xmlNodePtr globalDeclarations =

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -886,6 +886,7 @@ buildCode(
       parseTypeTable(typeTableNode, ctxt, ss),
       analyzeNnsTable(nnsTableNode, ctxt),
       getSourceLanguage(rootNode, ctxt),
+      {},
   };
 
   cxxgen::Stream out;

--- a/XcodeMLtoCXX/src/LibXMLUtil.cpp
+++ b/XcodeMLtoCXX/src/LibXMLUtil.cpp
@@ -98,6 +98,11 @@ getName(xmlNodePtr node) {
 }
 
 bool
+isEmpty(xmlNodePtr node) {
+  return getContent(node).empty();
+}
+
+bool
 isTrueProp(xmlNodePtr node, const char *name, bool default_value) {
   if (!xmlHasProp(node, BAD_CAST name)) {
     return default_value;

--- a/XcodeMLtoCXX/src/LibXMLUtil.h
+++ b/XcodeMLtoCXX/src/LibXMLUtil.h
@@ -17,6 +17,7 @@ std::string getProp(xmlNodePtr node, const std::string &attr);
 llvm::Optional<std::string> getPropOrNull(xmlNodePtr, const std::string &);
 std::string getContent(xmlNodePtr);
 std::string getName(xmlNodePtr);
+bool isEmpty(xmlNodePtr);
 
 /* Utility for XcodeML */
 bool isTrueProp(xmlNodePtr node, const char *name, bool default_value);

--- a/XcodeMLtoCXX/src/Makefile
+++ b/XcodeMLtoCXX/src/Makefile
@@ -23,6 +23,7 @@ OBJS = XcodeMlType.o \
 	TypeAnalyzer.o \
 	XMLString.o \
 	XcodeMlEnvironment.o \
+	SourceInfo.o \
 	StringTree.o \
 	ClangClassHandler.o \
 	XcodeMlName.o \

--- a/XcodeMLtoCXX/src/SourceInfo.cpp
+++ b/XcodeMLtoCXX/src/SourceInfo.cpp
@@ -1,0 +1,25 @@
+#include <memory>
+#include <string>
+#include <map>
+#include <vector>
+#include <libxml/tree.h>
+#include <libxml/xpath.h>
+#include "llvm/ADT/Optional.h"
+
+#include "StringTree.h"
+#include "XcodeMlNns.h"
+#include "XcodeMlType.h"
+#include "XcodeMlEnvironment.h"
+
+#include "SourceInfo.h"
+
+SourceInfo::SourceInfo(xmlXPathContextPtr c,
+    const XcodeMl::Environment &e,
+    const XcodeMl::NnsMap &n)
+    : ctxt(c), typeTable(e), nnsTable(n), uniqueNameIndex(0) {
+}
+
+std::string
+SourceInfo::getUniqueName() {
+  return std::string("__xcodeml_") + std::to_string(++uniqueNameIndex);
+}

--- a/XcodeMLtoCXX/src/SourceInfo.cpp
+++ b/XcodeMLtoCXX/src/SourceInfo.cpp
@@ -15,8 +15,9 @@
 
 SourceInfo::SourceInfo(xmlXPathContextPtr c,
     const XcodeMl::Environment &e,
-    const XcodeMl::NnsMap &n)
-    : ctxt(c), typeTable(e), nnsTable(n), uniqueNameIndex(0) {
+    const XcodeMl::NnsMap &n,
+    Language l)
+    : ctxt(c), typeTable(e), nnsTable(n), language(l), uniqueNameIndex(0) {
 }
 
 std::string

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -17,7 +17,6 @@ public:
   XcodeMl::Environment typeTable;
   XcodeMl::NnsMap nnsTable;
   Language language;
-  std::map<std::string, CXXCodeGen::StringTreeRef> unnamedClassDecls;
 };
 
 #endif /* !SOURCEINFO_H */

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -13,10 +13,15 @@ enum class Language {
  */
 class SourceInfo {
 public:
+  std::string getUniqueName();
+
   xmlXPathContextPtr ctxt;
   XcodeMl::Environment typeTable;
   XcodeMl::NnsMap nnsTable;
   Language language;
+
+private:
+  size_t uniqueNameIndex;
 };
 
 #endif /* !SOURCEINFO_H */

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -1,6 +1,10 @@
 #ifndef SOURCEINFO_H
 #define SOURCEINFO_H
 
+namespace XcodeMl {
+class Environment;
+} // namespace XcodeMl
+
 enum class Language {
   Invalid,
   C,
@@ -13,6 +17,9 @@ enum class Language {
  */
 class SourceInfo {
 public:
+  explicit SourceInfo(xmlXPathContextPtr c,
+      const XcodeMl::Environment &e,
+      const XcodeMl::NnsMap &n);
   std::string getUniqueName();
 
   xmlXPathContextPtr ctxt;

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -17,6 +17,7 @@ public:
   XcodeMl::Environment typeTable;
   XcodeMl::NnsMap nnsTable;
   Language language;
+  std::map<std::string, CXXCodeGen::StringTreeRef> unnamedClassDecls;
 };
 
 #endif /* !SOURCEINFO_H */

--- a/XcodeMLtoCXX/src/SourceInfo.h
+++ b/XcodeMLtoCXX/src/SourceInfo.h
@@ -19,7 +19,8 @@ class SourceInfo {
 public:
   explicit SourceInfo(xmlXPathContextPtr c,
       const XcodeMl::Environment &e,
-      const XcodeMl::NnsMap &n);
+      const XcodeMl::NnsMap &n,
+      Language l);
   std::string getUniqueName();
 
   xmlXPathContextPtr ctxt;

--- a/tests/Compilability/unnamed_class.src.cpp
+++ b/tests/Compilability/unnamed_class.src.cpp
@@ -1,0 +1,4 @@
+class {
+public:
+  int a;
+} A;

--- a/tests/Compilability/unnamed_class_with_multi_vars.src.cpp
+++ b/tests/Compilability/unnamed_class_with_multi_vars.src.cpp
@@ -1,0 +1,11 @@
+struct {
+  int a;
+  int b;
+} obj1, obj2;
+
+int
+main() {
+  obj2.a = 100;
+  obj1 = obj2;
+  return 0;
+}


### PR DESCRIPTION
* テストケースを追加した
* 逆変換で、無名クラスに`__xcodeml_1`のような名前を付けて復元するようにした

はじめ、無名クラスを無名クラスのまま復元するよう試みましたが、色々問題があり諦めました(f7357097b5353c41e0e9bec3a23221d7ff7e34e8)。