### PR TITLE
 Add increment/decrement operators to `opMap` 

### DIFF
--- a/XcodeMLtoCXX/src/XcodeMlOperator.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlOperator.cpp
@@ -25,6 +25,11 @@ const std::map<std::string, std::string> opMap = {
     {"bitOrExpr", "|"},
     {"bitXorExpr", "^"},
 
+    {"preIncrExpr", "++"},
+    {"preDecrExpr", "--"},
+    {"postIncrExpr", "++"},
+    {"postDecrExpr", "--"},
+
     {"assignExpr", "="},
     {"asgPlusExpr", "+="},
     {"asgMinusExpr", "-="},

--- a/tests/Compilability/operator_decrement.src.cpp
+++ b/tests/Compilability/operator_decrement.src.cpp
@@ -1,0 +1,15 @@
+class ClassA {
+public:
+  ClassA operator--() {
+    --i;
+    return *this;
+  }
+  const ClassA operator--(int) {
+    ClassA temp(*this);
+    --*this;
+    return temp;
+  }
+
+private:
+  int i;
+};

--- a/tests/Compilability/operator_increment.src.cpp
+++ b/tests/Compilability/operator_increment.src.cpp
@@ -1,0 +1,15 @@
+class ClassA {
+public:
+  ClassA operator++() {
+    ++i;
+    return *this;
+  }
+  const ClassA operator++(int) {
+    ClassA temp(*this);
+    ++*this;
+    return temp;
+  }
+
+private:
+  int i;
+};


### PR DESCRIPTION
逆変換で、インクリメント/デクリメント演算子を `opMap` に追加するのを忘れていたので追加した。