### PR TITLE
Emit explicitly-specified function template arguments

### DIFF
--- a/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
+++ b/CXXtoXML/src/XSLTs/Program2XcodeProgram.xsl
@@ -321,18 +321,6 @@
     </newExpr>
   </xsl:template>
 
-  <xsl:template match="clangStmt[@class='DeclRefExpr']">
-    <Var>
-      <xsl:if test="clangNestedNameSpecifier">
-        <xsl:attribute name="nns">
-          <xsl:value-of select="clangNestedNameSpecifier/@nns" />
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:value-of
-        select="clangDeclarationNameInfo[@class='Identifier']" />
-    </Var>
-  </xsl:template>
-
   <xsl:template match="clangStmt[
     @class='UnaryOperator' and @unaryOpName]">
     <xsl:element name="{@unaryOpName}">

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -237,3 +237,9 @@ const ClangClassHandler ClangDeclHandler("class",
         std::make_tuple("FunctionTemplate", FunctionTemplateProc),
         std::make_tuple("TemplateTypeParm", TemplateTypeParmProc),
     });
+
+DEFINE_CCH(BuiltinTypeProc) {
+  const auto dtident = getProp(node, "type");
+  return makeDecl(
+      src.typeTable.at(dtident), cxxgen::makeVoidNode(), src.typeTable);
+}

--- a/XcodeMLtoCXX/src/ClangClassHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangClassHandler.cpp
@@ -243,3 +243,10 @@ DEFINE_CCH(BuiltinTypeProc) {
   return makeDecl(
       src.typeTable.at(dtident), cxxgen::makeVoidNode(), src.typeTable);
 }
+
+const ClangClassHandler ClangTypeLocHandler("class",
+    cxxgen::makeInnerNode,
+    callCodeBuilder,
+    {
+        std::make_tuple("Builtin", BuiltinTypeProc),
+    });

--- a/XcodeMLtoCXX/src/ClangClassHandler.h
+++ b/XcodeMLtoCXX/src/ClangClassHandler.h
@@ -6,5 +6,6 @@ using ClangClassHandler =
 
 extern const ClangClassHandler ClangStmtHandler;
 extern const ClangClassHandler ClangDeclHandler;
+extern const ClangClassHandler ClangTypeLocHandler;
 
 #endif /* !CLANGCLASSHANDLER_H */

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -734,6 +734,10 @@ DEFINE_CB(clangDeclProc) {
   return ClangDeclHandler.walk(node, w, src);
 }
 
+DEFINE_CB(clangTypeLocProc) {
+  return ClangTypeLocHandler.walk(node, w, src);
+}
+
 } // namespace
 
 const CodeBuilder ProgramBuilder("ProgramBuilder",
@@ -827,6 +831,7 @@ const CodeBuilder ProgramBuilder("ProgramBuilder",
         /* for elements defined by clang */
         std::make_tuple("clangStmt", clangStmtProc),
         std::make_tuple("clangDecl", clangDeclProc),
+        std::make_tuple("clangTypeLoc", clangTypeLocProc),
 
         /* for CtoXcodeML */
         std::make_tuple("Decl_Record", NullProc),

--- a/tests/Compilability/templ_func_explicit_templ_arg.src.cpp
+++ b/tests/Compilability/templ_func_explicit_templ_arg.src.cpp
@@ -1,0 +1,10 @@
+template <typename T>
+int
+func(T *ptr) {
+  return 0;
+}
+
+int
+main() {
+  int i = func<void>(0);
+}


### PR DESCRIPTION
逆変換を更新して, 明示的に指定された関数テンプレートのテンプレート実引数 (例: `func<int, int>()`) を復元するようにした.