### PR TITLE
Emit `name/@test_nns`, `name/@test_nns_decl_kind`

### DIFF
--- a/CXXtoXML/src/DeclarationsVisitor.cpp
+++ b/CXXtoXML/src/DeclarationsVisitor.cpp
@@ -340,6 +340,20 @@ DeclarationsVisitor::PreVisitDecl(Decl *D) {
   NamedDecl *ND = dyn_cast<NamedDecl>(D);
   if (ND) {
     auto nameNode = makeNameNode(*typetableinfo, ND);
+
+    /* experimental */
+    const auto D1 = ND->getDeclContext();
+    assert(D1);
+    const auto D2 = D1->getParent();
+    // const auto parent =  D2 ? D2 : D1;
+    const auto parent = D1;
+    xmlNewProp(nameNode,
+        BAD_CAST "test_nns_decl_kind",
+        BAD_CAST(parent->getDeclKindName()));
+    xmlNewProp(nameNode,
+        BAD_CAST "test_nns",
+        BAD_CAST(nnstableinfo->getNnsName(parent).c_str()));
+
     xmlAddChild(curNode, nameNode);
   }
 

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -15,7 +15,7 @@ namespace {
 xmlNodePtr getNnsDefElem(
     const NnsTableInfoImpl &, const clang::NestedNameSpecifier *);
 
-void pushNns(NnsTableInfoImpl &, const clang::NestedNameSpecifier *);
+void pushNns(NnsTableInfoImpl &, const std::string &);
 
 void registerNestedNameSpec(
     NnsTableInfoImpl &, const clang::NestedNameSpecifier *);
@@ -48,11 +48,9 @@ struct NnsTableInfoImpl {
    *  Each node-NNSs pair consists
    *  - an XML <nnsTable> element (`xmlNodePtr`)
    *  - and a list of NNSs that belong to the NNS-scope
-   *    defined by the <nnsTable> element
-   *    (std::vector<const clang::NestedNameSpecifier *>>)
+   *    defined by the <nnsTable> element (`std::vector<std::string>`)
    */
-  std::stack<std::tuple<xmlNodePtr,
-      std::vector<const clang::NestedNameSpecifier *>>> nnsTableStack;
+  std::stack<std::tuple<xmlNodePtr, std::vector<std::string>>> nnsTableStack;
 
   size_t seqForOther;
   std::map<const clang::NestedNameSpecifier *, std::string> mapForOtherNns;
@@ -90,16 +88,16 @@ NnsTableInfo::getNnsName(const clang::NestedNameSpecifier *NestedNameSpec) {
 namespace {
 
 void
-pushNns(NnsTableInfoImpl &info, const clang::NestedNameSpecifier *Spec) {
-  std::get<1>(info.nnsTableStack.top()).push_back(Spec);
+pushNns(NnsTableInfoImpl &info, const std::string &nns) {
+  std::get<1>(info.nnsTableStack.top()).push_back(nns);
 }
 
 } // namespace
 
 void
 NnsTableInfo::pushNnsTableStack(xmlNodePtr nnsTableNode) {
-  pimpl->nnsTableStack.push(std::make_tuple(
-      nnsTableNode, std::vector<const clang::NestedNameSpecifier *>()));
+  pimpl->nnsTableStack.push(
+      std::make_tuple(nnsTableNode, std::vector<std::string>()));
 }
 
 void
@@ -187,7 +185,7 @@ registerNestedNameSpec(
   info.mapFromNestedNameSpecToXmlNodePtr[NestedNameSpec] =
       makeNnsDefNodeForNestedNameSpec(
           *(info.mangleContext), info, *info.typetableinfo, NestedNameSpec);
-  pushNns(info, NestedNameSpec);
+  pushNns(info, name);
 }
 
 xmlNodePtr

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -6,6 +6,7 @@
 #include <libxml/tree.h>
 #include "clang/AST/Mangle.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclBase.h"
 #include "TypeTableInfo.h"
 
 #include "NnsTableInfo.h"
@@ -53,6 +54,8 @@ struct NnsTableInfoImpl {
   /*! counter for others */
   size_t seqForOther;
   std::map<const clang::NestedNameSpecifier *, std::string> mapForOtherNns;
+
+  std::map<const clang::DeclContext *, std::string> mapForDC;
 };
 
 NnsTableInfo::NnsTableInfo(clang::MangleContext *MC, TypeTableInfo *TTI)

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -20,6 +20,8 @@ void pushNns(NnsTableInfoImpl &, const std::string &);
 void registerNestedNameSpec(
     NnsTableInfoImpl &, const clang::NestedNameSpecifier *);
 
+void registerNestedNameSpec(NnsTableInfoImpl &, const clang::DeclContext *DC);
+
 template <typename T, typename... Ts>
 std::unique_ptr<T>
 make_unique(Ts &&... params) {
@@ -187,6 +189,19 @@ registerNestedNameSpec(
   info.mapFromNnsIdentToXmlNodePtr[name] = makeNnsDefNodeForNestedNameSpec(
       *(info.mangleContext), info, *info.typetableinfo, NestedNameSpec);
   pushNns(info, name);
+}
+
+void
+registerNestedNameSpec(NnsTableInfoImpl &info, const clang::DeclContext *DC) {
+  assert(DC);
+
+  if (DC->getDeclKind() == clang::Decl::TranslationUnit) {
+    // no need to register
+    return;
+  }
+  const auto prefix = static_cast<std::string>("NNS");
+  const auto name = prefix + std::to_string(info.seqForOther++);
+  info.mapForDC[DC] = name;
 }
 
 xmlNodePtr

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -33,6 +33,7 @@ struct NnsTableInfoImpl {
       : mangleContext(MC),
         typetableinfo(TTI),
         mapFromNestedNameSpecToXmlNodePtr(),
+        nnsTableStack(),
         seqForOther(0),
         mapForOtherNns() {
     assert(typetableinfo);

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -50,6 +50,7 @@ struct NnsTableInfoImpl {
    */
   std::stack<std::tuple<xmlNodePtr, std::vector<std::string>>> nnsTableStack;
 
+  /*! counter for others */
   size_t seqForOther;
   std::map<const clang::NestedNameSpecifier *, std::string> mapForOtherNns;
 };

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -12,8 +12,7 @@
 
 namespace {
 
-xmlNodePtr getNnsDefElem(
-    const NnsTableInfoImpl &, const clang::NestedNameSpecifier *);
+xmlNodePtr getNnsDefElem(const NnsTableInfoImpl &, const std::string &);
 
 void pushNns(NnsTableInfoImpl &, const std::string &);
 
@@ -32,7 +31,7 @@ struct NnsTableInfoImpl {
   explicit NnsTableInfoImpl(clang::MangleContext *MC, TypeTableInfo *TTI)
       : mangleContext(MC),
         typetableinfo(TTI),
-        mapFromNestedNameSpecToXmlNodePtr(),
+        mapFromNnsIdentToXmlNodePtr(),
         nnsTableStack(),
         seqForOther(0),
         mapForOtherNns() {
@@ -41,8 +40,7 @@ struct NnsTableInfoImpl {
 
   clang::MangleContext *mangleContext;
   TypeTableInfo *typetableinfo;
-  std::map<const clang::NestedNameSpecifier *, xmlNodePtr>
-      mapFromNestedNameSpecToXmlNodePtr;
+  std::map<std::string, xmlNodePtr> mapFromNnsIdentToXmlNodePtr;
 
   /*! stack of node-NNSs pairs.
    *  Each node-NNSs pair consists
@@ -182,17 +180,15 @@ registerNestedNameSpec(
   const auto prefix = static_cast<std::string>("NNS");
   const auto name = prefix + std::to_string(info.seqForOther++);
   info.mapForOtherNns[NestedNameSpec] = name;
-  info.mapFromNestedNameSpecToXmlNodePtr[NestedNameSpec] =
-      makeNnsDefNodeForNestedNameSpec(
-          *(info.mangleContext), info, *info.typetableinfo, NestedNameSpec);
+  info.mapFromNnsIdentToXmlNodePtr[name] = makeNnsDefNodeForNestedNameSpec(
+      *(info.mangleContext), info, *info.typetableinfo, NestedNameSpec);
   pushNns(info, name);
 }
 
 xmlNodePtr
-getNnsDefElem(
-    const NnsTableInfoImpl &info, const clang::NestedNameSpecifier *Spec) {
-  const auto iter = info.mapFromNestedNameSpecToXmlNodePtr.find(Spec);
-  assert(iter != info.mapFromNestedNameSpecToXmlNodePtr.cend());
+getNnsDefElem(const NnsTableInfoImpl &info, const std::string &nns) {
+  const auto iter = info.mapFromNnsIdentToXmlNodePtr.find(nns);
+  assert(iter != info.mapFromNnsIdentToXmlNodePtr.cend());
   return iter->second;
 }
 

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -106,7 +106,7 @@ NnsTableInfo::popNnsTableStack() {
 namespace {
 
 xmlNodePtr
-makeNnsIdentNodeForType(NnsTableInfoImpl &info,
+makeNnsDefNodeForType(NnsTableInfoImpl &info,
     TypeTableInfo &TTI,
     const clang::NestedNameSpecifier *Spec) {
   assert(Spec);
@@ -135,17 +135,17 @@ dump(const clang::NestedNameSpecifier &Spec, const clang::MangleContext &MC) {
 }
 
 xmlNodePtr
-makeNnsIdentNodeForNestedNameSpec(const clang::MangleContext &MC,
+makeNnsDefNodeForNestedNameSpec(const clang::MangleContext &MC,
     NnsTableInfoImpl &info,
     TypeTableInfo &TTI,
     const clang::NestedNameSpecifier *Spec) {
   assert(Spec);
   using SK = clang::NestedNameSpecifier::SpecifierKind;
   switch (Spec->getKind()) {
-  case SK::TypeSpec: return makeNnsIdentNodeForType(info, TTI, Spec);
+  case SK::TypeSpec: return makeNnsDefNodeForType(info, TTI, Spec);
 
   case SK::Global:
-    // do not make Nns Identifier node for global namespace
+    // do not make Nns definition node for global namespace
     assert(false);
 
   case SK::Identifier:
@@ -175,7 +175,7 @@ registerNestedNameSpec(
   const auto name = prefix + std::to_string(info.seqForOther++);
   info.mapForOtherNns[NestedNameSpec] = name;
   info.mapFromNestedNameSpecToXmlNodePtr[NestedNameSpec] =
-      makeNnsIdentNodeForNestedNameSpec(
+      makeNnsDefNodeForNestedNameSpec(
           *(info.mangleContext), info, *info.typetableinfo, NestedNameSpec);
   pushNns(info, NestedNameSpec);
 }

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-xmlNodePtr getNnsNode(
+xmlNodePtr getNnsDefElem(
     const NnsTableInfoImpl &, const clang::NestedNameSpecifier *);
 
 void pushNns(NnsTableInfoImpl &, const clang::NestedNameSpecifier *);
@@ -98,7 +98,7 @@ NnsTableInfo::popNnsTableStack() {
   const auto nnsTableNode = std::get<0>(pimpl->nnsTableStack.top());
   const auto nnssInCurScope = std::get<1>(pimpl->nnsTableStack.top());
   for (auto &nns : nnssInCurScope) {
-    xmlAddChild(nnsTableNode, getNnsNode(*pimpl, nns));
+    xmlAddChild(nnsTableNode, getNnsDefElem(*pimpl, nns));
   }
   pimpl->nnsTableStack.pop();
 }
@@ -181,7 +181,7 @@ registerNestedNameSpec(
 }
 
 xmlNodePtr
-getNnsNode(
+getNnsDefElem(
     const NnsTableInfoImpl &info, const clang::NestedNameSpecifier *Spec) {
   const auto iter = info.mapFromNestedNameSpecToXmlNodePtr.find(Spec);
   assert(iter != info.mapFromNestedNameSpecToXmlNodePtr.cend());

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -44,6 +44,14 @@ struct NnsTableInfoImpl {
   std::map<const clang::NestedNameSpecifier *, std::string> mapForOtherNns;
   std::map<const clang::NestedNameSpecifier *, xmlNodePtr>
       mapFromNestedNameSpecToXmlNodePtr;
+
+  /*! stack of node-NNSs pairs.
+   *  Each node-NNSs pair consists
+   *  - an XML <nnsTable> element (`xmlNodePtr`)
+   *  - and a list of NNSs that belong to the NNS-scope
+   *    defined by the <nnsTable> element
+   *    (std::vector<const clang::NestedNameSpecifier *>>)
+   */
   std::stack<std::tuple<xmlNodePtr,
       std::vector<const clang::NestedNameSpecifier *>>> nnsTableStack;
 };

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -192,6 +192,18 @@ makeNnsDefNodeForNestedNameSpec(const clang::MangleContext &MC,
   return nullptr;
 }
 
+xmlNodePtr
+makeNnsDefNodeForDeclContext(const clang::MangleContext &MC,
+    NnsTableInfoImpl &info,
+    TypeTableInfo &TTI,
+    const clang::DeclContext *DC) {
+  using namespace clang;
+  assert(DC);
+  const auto node = xmlNewNode(nullptr, BAD_CAST "DCNNS");
+  xmlNewProp(node, BAD_CAST "kind", BAD_CAST(DC->getDeclKindName()));
+  return node;
+}
+
 void
 registerNestedNameSpec(
     NnsTableInfoImpl &info, const clang::NestedNameSpecifier *NestedNameSpec) {

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -82,6 +82,21 @@ getOrRegisterNnsName(
   return info.mapForOtherNns[NestedNameSpec];
 }
 
+std::string
+getOrRegisterNnsName(NnsTableInfoImpl &info, const clang::DeclContext *DC) {
+  using namespace clang;
+
+  const auto kind = DC->getDeclKind();
+  if (kind == Decl::TranslationUnit) {
+    return "global";
+  }
+
+  if (info.mapForDC.count(DC) == 0) {
+    registerNestedNameSpec(info, DC);
+  }
+  return info.mapForDC[DC];
+}
+
 } // namespace
 
 std::string

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -38,7 +38,7 @@ struct NnsTableInfoImpl {
     assert(typetableinfo);
   }
 
-  int seqForOther;
+  size_t seqForOther;
   clang::MangleContext *mangleContext;
   TypeTableInfo *typetableinfo;
   std::map<const clang::NestedNameSpecifier *, std::string> mapForOtherNns;

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -104,6 +104,11 @@ NnsTableInfo::getNnsName(const clang::NestedNameSpecifier *NestedNameSpec) {
   return getOrRegisterNnsName(*pimpl, NestedNameSpec);
 }
 
+std::string
+NnsTableInfo::getNnsName(const clang::DeclContext *DC) {
+  return getOrRegisterNnsName(*pimpl, DC);
+}
+
 namespace {
 
 void

--- a/CXXtoXML/src/NnsTableInfo.cpp
+++ b/CXXtoXML/src/NnsTableInfo.cpp
@@ -30,18 +30,16 @@ make_unique(Ts &&... params) {
 
 struct NnsTableInfoImpl {
   explicit NnsTableInfoImpl(clang::MangleContext *MC, TypeTableInfo *TTI)
-      : seqForOther(0),
-        mangleContext(MC),
+      : mangleContext(MC),
         typetableinfo(TTI),
-        mapForOtherNns(),
-        mapFromNestedNameSpecToXmlNodePtr() {
+        mapFromNestedNameSpecToXmlNodePtr(),
+        seqForOther(0),
+        mapForOtherNns() {
     assert(typetableinfo);
   }
 
-  size_t seqForOther;
   clang::MangleContext *mangleContext;
   TypeTableInfo *typetableinfo;
-  std::map<const clang::NestedNameSpecifier *, std::string> mapForOtherNns;
   std::map<const clang::NestedNameSpecifier *, xmlNodePtr>
       mapFromNestedNameSpecToXmlNodePtr;
 
@@ -54,6 +52,9 @@ struct NnsTableInfoImpl {
    */
   std::stack<std::tuple<xmlNodePtr,
       std::vector<const clang::NestedNameSpecifier *>>> nnsTableStack;
+
+  size_t seqForOther;
+  std::map<const clang::NestedNameSpecifier *, std::string> mapForOtherNns;
 };
 
 NnsTableInfo::NnsTableInfo(clang::MangleContext *MC, TypeTableInfo *TTI)

--- a/CXXtoXML/src/NnsTableInfo.h
+++ b/CXXtoXML/src/NnsTableInfo.h
@@ -16,6 +16,7 @@ public:
 
   explicit NnsTableInfo(clang::MangleContext *, TypeTableInfo *);
   std::string getNnsName(const clang::NestedNameSpecifier *);
+  std::string getNnsName(const clang::DeclContext *);
   void popNnsTableStack();
   void pushNnsTableStack(xmlNodePtr);
 

--- a/tests/Compilability/various_decl_context.src.cpp
+++ b/tests/Compilability/various_decl_context.src.cpp
@@ -1,0 +1,20 @@
+void
+func(int func_i, int func_j) {
+  int func_x;
+}
+
+extern "C" {
+
+void
+extC_func(int extC_func_i) {
+  int extC_func_x;
+}
+}
+
+class Record {
+  void
+  Record_memfn(int Record_memfn_i) {
+    int Record_memfn_x;
+  }
+  int Record_field;
+};

--- a/tests/Compilability/various_decl_context.src.cpp
+++ b/tests/Compilability/various_decl_context.src.cpp
@@ -3,6 +3,15 @@ func(int func_i, int func_j) {
   int func_x;
 }
 
+namespace ns {
+
+void
+ns_func(int ns_func_i) {
+  int ns_func_x;
+}
+
+} // namespace ns
+
 extern "C" {
 
 void


### PR DESCRIPTION
正変換を更新して、 `name`要素が`test_nns`属性および`test_nns_decl_kind`属性を持つようにしました。詳細については各コミットメッセージを参照してください。

`test_nns`属性および`test_nns_decl_kind`属性は暫定的なものであり、今後変更されます。しかしこのままmasterに取り込んでも特に害はないので、diffがこれ(+128, -29)以上大きくなることを避けるために今の状態でプルリクエストを出します。