### PR TITLE
Emit spaces before colons (XcodeMLtoCXX)

### DIFF
--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -104,7 +104,7 @@ isAllowedInIdent(char c) {
 bool
 shouldInterleaveSpace(char last, char next) {
   const std::string operators = "+-*/%^&|!><";
-  const std::string repeatables = "+-><&|=";
+  const std::string repeatables = "+-><&|=:";
   return (isAllowedInIdent(last) && isAllowedInIdent(next))
       || (operators.find(last) != std::string::npos && next == '=')
       || (last == next && repeatables.find(last) != std::string::npos)

--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -108,6 +108,10 @@ shouldInterleaveSpace(char last, char next) {
   return (isAllowedInIdent(last) && isAllowedInIdent(next))
       || (operators.find(last) != std::string::npos && next == '=')
       || (last == next && repeatables.find(last) != std::string::npos)
+      || (next == ':')
+      /* `label1:::i = 1;`
+       * `void::Class1::func() { }`
+       */
       || (last == '-' && next == '>') || // `->`
       (last == '>' && next == '*'); // `->*`
 }

--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -108,10 +108,6 @@ shouldInterleaveSpace(char last, char next) {
   return (isAllowedInIdent(last) && isAllowedInIdent(next))
       || (operators.find(last) != std::string::npos && next == '=')
       || (last == next && repeatables.find(last) != std::string::npos)
-      || (next == ':')
-      /* `label1:::i = 1;`
-       * `void::Class1::func() { }`
-       */
       || (last == '-' && next == '>') || // `->`
       (last == '>' && next == '*'); // `->*`
 }

--- a/XcodeMLtoCXX/tests/UnitTest/CXXCodeGenStream.cpp
+++ b/XcodeMLtoCXX/tests/UnitTest/CXXCodeGenStream.cpp
@@ -90,6 +90,8 @@ BOOST_AUTO_TEST_CASE(space_interleaving_test) {
       {"_", "1"},
       {"+", "+"},
       {"+", "="},
+      {"label1:", "::i = 1;"},
+      {"void", "::ClassA::func() { }"},
   };
 
   for (auto &&tc : testcases) {

--- a/XcodeMLtoCXX/tests/UnitTest/CXXCodeGenStream.cpp
+++ b/XcodeMLtoCXX/tests/UnitTest/CXXCodeGenStream.cpp
@@ -91,7 +91,6 @@ BOOST_AUTO_TEST_CASE(space_interleaving_test) {
       {"+", "+"},
       {"+", "="},
       {"label1:", "::i = 1;"},
-      {"void", "::ClassA::func() { }"},
   };
 
   for (auto &&tc : testcases) {


### PR DESCRIPTION
Update XcodeMLtoCXX/src/Stream.cpp.

Rewrite `shouldInterleaveSpace(char, char)` and emit spaces (' ') before
emitting colons (':') in output C++ program.

Example 1:

    label1:::i = 1;  // error
    label1: ::i = 1; // OK

~Example 2:~

~void::Class1::func() { }  // error~
~void ::Class1::func() { } // OK~