### PR TITLE
Fix typo in tests/compile/class_templ_decl.src.cpp

### DIFF
--- a/tests/compile/class_templ_decl.src.cpp
+++ b/tests/compile/class_templ_decl.src.cpp
@@ -1,4 +1,4 @@
-tempalte<typename T> class ClassA {
+template<typename T> class ClassA {
 public:
   int
   get() {

--- a/tests/compile/class_templ_decl.src.cpp
+++ b/tests/compile/class_templ_decl.src.cpp
@@ -1,4 +1,5 @@
-template<typename T> class ClassA {
+template <typename T>
+class ClassA {
 public:
   int
   get() {


### PR DESCRIPTION
```
tempalte<typename T> class ClassA {
```