### PR TITLE
Call `registerPointerType` for type `T` before registering its pointee type in TypeTableInfo

### DIFF
--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -370,11 +370,11 @@ TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
     case Type::Pointer:
     case Type::BlockPointer:
     case Type::MemberPointer: {
+      rawname = registerPointerType(T);
       const PointerType *PT = dyn_cast<const PointerType>(T.getTypePtr());
       if (PT) {
         registerType(PT->getPointeeType(), nullptr, nullptr);
       }
-      rawname = registerPointerType(T);
       Node = createNode(T, "pointerType", nullptr);
       if (PT) {
         xmlNewProp(Node,

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -387,10 +387,6 @@ TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
     case Type::LValueReference:
     case Type::RValueReference: {
       const auto RT = dyn_cast<ReferenceType>(T.getTypePtr());
-      const auto Pointee = RT->getPointeeType();
-      if (RT) {
-        registerType(Pointee, nullptr, nullptr);
-      }
       rawname = registerPointerType(T);
       Node = createNode(T, "pointerType", nullptr);
       xmlNewProp(Node,
@@ -398,6 +394,8 @@ TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
           T->getTypeClass() == Type::LValueReference ? BAD_CAST "lvalue"
                                                      : BAD_CAST "rvalue");
       if (RT) {
+        const auto Pointee = RT->getPointeeType();
+        registerType(Pointee, nullptr, nullptr);
         xmlNewProp(
             Node, BAD_CAST "ref", BAD_CAST getTypeName(Pointee).c_str());
       }

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -371,12 +371,10 @@ TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
     case Type::BlockPointer:
     case Type::MemberPointer: {
       rawname = registerPointerType(T);
-      const PointerType *PT = dyn_cast<const PointerType>(T.getTypePtr());
-      if (PT) {
-        registerType(PT->getPointeeType(), nullptr, nullptr);
-      }
       Node = createNode(T, "pointerType", nullptr);
-      if (PT) {
+      if (const PointerType *PT =
+              dyn_cast<const PointerType>(T.getTypePtr())) {
+        registerType(PT->getPointeeType(), nullptr, nullptr);
         xmlNewProp(Node,
             BAD_CAST "ref",
             BAD_CAST getTypeName(PT->getPointeeType()).c_str());

--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -384,14 +384,13 @@ TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
 
     case Type::LValueReference:
     case Type::RValueReference: {
-      const auto RT = dyn_cast<ReferenceType>(T.getTypePtr());
       rawname = registerPointerType(T);
       Node = createNode(T, "pointerType", nullptr);
       xmlNewProp(Node,
           BAD_CAST "reference",
           T->getTypeClass() == Type::LValueReference ? BAD_CAST "lvalue"
                                                      : BAD_CAST "rvalue");
-      if (RT) {
+      if (const auto RT = dyn_cast<ReferenceType>(T.getTypePtr())) {
         const auto Pointee = RT->getPointeeType();
         registerType(Pointee, nullptr, nullptr);
         xmlNewProp(

--- a/tests/compile/recursive_struct.src.cpp
+++ b/tests/compile/recursive_struct.src.cpp
@@ -1,0 +1,9 @@
+struct A {
+public:
+  struct B *ptr1;
+};
+
+struct B {
+public:
+  struct B *ptr2;
+};

--- a/tests/compile/recursive_struct_reference.src.cpp
+++ b/tests/compile/recursive_struct_reference.src.cpp
@@ -1,0 +1,9 @@
+struct A {
+public:
+  struct B &r1;
+};
+
+struct B {
+public:
+  struct B &r2;
+};


### PR DESCRIPTION
Problem: CXXtoXML aborts when the input C/C++ program has a struct declaration (hereinafter referred to as `struct B`) that has a member of pointer-to-struct-B type, and another struct that is declared before the declaration of `struct B` (hereinafter referred to as `struct A`) also has a member of pointer-to-struct-B type, e.g.

    struct A {
        struct B *ptr1;
    };
    struct B {
        struct B *ptr2;
    };

Solution: Change the order of procedures in `TypeTableInfo::registerType`, and apply `TypeTableInfo::registerPointerType` to type `T` before applying `TypeTableInfo::registerType` to `clang::dyn_cast<const clang::PointerType>(T.getTypePtr())->getPointeeType()`.