### PR TITLE
StringTree: add SourcePosNode

### DIFF
--- a/XcodeMLtoCXX/src/Stream.cpp
+++ b/XcodeMLtoCXX/src/Stream.cpp
@@ -118,7 +118,7 @@ Stream::insertNewLine() {
     std::tie(filename, lineno) = *(pimpl->currline);
 
     const auto directive =
-        std::string("#line ") + filename + " " + std::to_string(lineno);
+      std::string("#line ") + std::to_string(lineno) + "\"" + filename + "\"";
     emit(*pimpl, std::string("\n") + directive + "\n");
     pimpl->nextline = StreamImpl::LineInfo(filename, lineno + 1);
   } else {

--- a/XcodeMLtoCXX/src/StringTree.cpp
+++ b/XcodeMLtoCXX/src/StringTree.cpp
@@ -120,6 +120,32 @@ NewLineNode::getsingleton() {
   return singletonptr;
 }
 
+bool
+SourcePosNode::classof(const StringTree *node) {
+  return node->getKind() == StringTreeKind::NewLine;
+}
+
+SourcePosNode::SourcePosNode(std::string f, size_t l)
+  : StringTree(StringTreeKind::SourcePos), filename(f), lineno(l) {
+};
+
+StringTree *
+SourcePosNode::clone() const {
+  return (StringTree *)this;
+}
+
+void
+SourcePosNode::flush(Stream &ss) const {
+  ss.setLineInfo(filename, lineno);
+}
+
+InnerNode *
+SourcePosNode::lift() const {
+  std::vector<StringTreeRef> v({std::make_shared<SourcePosNode>(filename, lineno)});
+  InnerNode *node = new InnerNode(v);
+  return node;
+}
+
 StringTreeRef
 makeInnerNode(const std::vector<StringTreeRef> &v) {
   return std::make_shared<InnerNode>(v);

--- a/XcodeMLtoCXX/src/StringTree.h
+++ b/XcodeMLtoCXX/src/StringTree.h
@@ -10,6 +10,8 @@ enum class StringTreeKind {
   Token,
   /*! leaf node which represents a "\n" */
   NewLine,
+  /*! leaf node which represents a source position */
+  SourcePos,
 };
 
 class InnerNode;
@@ -94,6 +96,23 @@ protected:
 };
 
 extern const NewLineNode newlinenode;
+
+class SourcePosNode : public StringTree {
+public:
+  static bool classof(const StringTree *);
+  explicit SourcePosNode(std::string, size_t);
+  ~SourcePosNode() = default;
+  StringTree *clone() const override;
+  void flush(Stream &) const override;
+  InnerNode *lift() const override;
+
+protected:
+  SourcePosNode(const SourcePosNode &) = default;
+
+private:
+  std::string filename;
+  size_t lineno;
+};
 
 class LineInfoNode : public StringTree {
 public:


### PR DESCRIPTION
#241 で StringTree に NewLineNode を追加してそれが Stream に伝わるようにしたのですが、
StringTree 経由で Stream の setLineInfo を呼ぶ手段が準備されていなかったので、
SourcePosNode というのを新たに追加しました。