### PR TITLE
Emit member initializer lists

### DIFF
--- a/XcodeMLtoCXX/src/ClangDeclHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangDeclHandler.cpp
@@ -84,9 +84,6 @@ makeMemberInitList(xmlNodePtr node, SourceInfo &src) {
   bool first = true;
   std::vector<CodeFragment> inits;
   for (auto &&initNode : initNodes) {
-    if (!isTrueProp(initNode, "is_written", 0)) {
-      continue;
-    }
     inits.push_back(ProgramBuilder.walk(initNode, src));
     first = false;
   }

--- a/XcodeMLtoCXX/src/ClangDeclHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangDeclHandler.cpp
@@ -260,6 +260,9 @@ DEFINE_DECLHANDLER(emitInlineMemberFunction) {
   if (!initNodes.empty()) {
     bool first = true;
     for (auto &&initNode : initNodes) {
+      if (!isTrueProp(initNode, "is_written", 0)) {
+        continue;
+      }
       const auto init = ProgramBuilder.walk(initNode, src);
       acc = acc + makeTokenNode(first ? ":" : ",") + init;
       first = false;
@@ -306,6 +309,9 @@ DEFINE_DECLHANDLER(FunctionProc) {
   if (!initNodes.empty()) {
     bool first = true;
     for (auto &&initNode : initNodes) {
+      if (!isTrueProp(initNode, "is_written", 0)) {
+        continue;
+      }
       const auto init = ProgramBuilder.walk(initNode, src);
       acc = acc + makeTokenNode(first ? ":" : ",") + init;
       first = false;

--- a/XcodeMLtoCXX/src/ClangDeclHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangDeclHandler.cpp
@@ -302,9 +302,14 @@ DEFINE_DECLHANDLER(FunctionProc) {
   const auto paramNames = getParamNames(node, src);
   auto acc = makeFunctionDeclHead(node, paramNames, src, true);
 
-  if (const auto ctorInitList =
-          findFirst(node, "constructorInitializerList", src.ctxt)) {
-    acc = acc + w.walk(ctorInitList, src);
+  const auto initNodes = findNodes(node, "clangConstructorInitializer", src.ctxt);
+  if (!initNodes.empty()) {
+    bool first = true;
+    for (auto &&initNode : initNodes) {
+      const auto init = ProgramBuilder.walk(initNode, src);
+      acc = acc + makeTokenNode(first ? ":" : ",") + init;
+      first = false;
+    }
   }
 
   if (const auto bodyNode = findFirst(node, "clangStmt", src.ctxt)) {

--- a/XcodeMLtoCXX/src/ClangDeclHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangDeclHandler.cpp
@@ -75,7 +75,8 @@ foldDecls(xmlNodePtr node, const CodeBuilder &w, SourceInfo &src) {
 
 CodeFragment
 makeMemberInitList(xmlNodePtr node, SourceInfo &src) {
-  const auto initNodes = findNodes(node, "clangConstructorInitializer", src.ctxt);
+  const auto initNodes =
+      findNodes(node, "clangConstructorInitializer", src.ctxt);
   if (initNodes.empty()) {
     return CXXCodeGen::makeVoidNode();
   }
@@ -182,8 +183,7 @@ emitClassDefinition(xmlNodePtr node,
       : classType.name().getValue();
 
   return classKey + name + makeBases(classType, src)
-      + wrapWithBrace(insertNewLines(decls))
-      + CXXCodeGen::makeNewLineNode();
+      + wrapWithBrace(insertNewLines(decls)) + CXXCodeGen::makeNewLineNode();
 }
 
 DEFINE_DECLHANDLER(ClassTemplatePartialSpecializationProc) {

--- a/XcodeMLtoCXX/src/ClangDeclHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangDeclHandler.cpp
@@ -256,9 +256,14 @@ DEFINE_DECLHANDLER(emitInlineMemberFunction) {
   const auto paramNames = getParamNames(node, src);
   acc = acc + makeFunctionDeclHead(node, paramNames, src);
 
-  if (const auto ctorInitList =
-          findFirst(node, "constructorInitializerList", src.ctxt)) {
-    acc = acc + ProgramBuilder.walk(ctorInitList, src);
+  const auto initNodes = findNodes(node, "clangConstructorInitializer", src.ctxt);
+  if (!initNodes.empty()) {
+    bool first = true;
+    for (auto &&initNode : initNodes) {
+      const auto init = ProgramBuilder.walk(initNode, src);
+      acc = acc + makeTokenNode(first ? ":" : ",") + init;
+      first = false;
+    }
   }
 
   if (const auto bodyNode = findFirst(node, "clangStmt", src.ctxt)) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -597,7 +597,7 @@ getCtorInitName(xmlNodePtr node, const XcodeMl::Environment &env) {
 
 DEFINE_CB(ctorInitProc) {
   const auto member = getCtorInitName(node, src.typeTable);
-  auto expr = findFirst(node, "*[1]", src.ctxt);
+  const auto expr = findFirst(node, "clangStmt[1]", src.ctxt);
   assert(expr);
   const auto astClass = getPropOrNull(expr, "class");
   if (astClass.hasValue() && (*astClass == "CXXConstructExpr")) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -581,21 +581,6 @@ DEFINE_CB(emitDataMemberDecl) {
   return wrapWithLangLink(acc, node, src);
 }
 
-DEFINE_CB(ctorInitListProc) {
-  auto inits = findNodes(node, "constructorInitializer", src.ctxt);
-  if (inits.empty()) {
-    return makeVoidNode();
-  }
-  auto decl = makeVoidNode();
-  bool alreadyPrinted = false;
-  for (auto init : inits) {
-    decl =
-        decl + makeTokenNode(alreadyPrinted ? "," : ":") + w.walk(init, src);
-    alreadyPrinted = true;
-  }
-  return decl;
-}
-
 XcodeMl::CodeFragment
 getCtorInitName(xmlNodePtr node, const XcodeMl::Environment &env) {
   const auto dataMember = getPropOrNull(node, "member");
@@ -738,7 +723,6 @@ const CodeBuilder ProgramBuilder("ProgramBuilder",
         std::make_tuple("value", valueProc),
 
         /* out of specification */
-        std::make_tuple("constructorInitializerList", ctorInitListProc),
         std::make_tuple(
             "xcodemlAccessToAnonRecordExpr", accessToAnonRecordExprProc),
 

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -738,7 +738,6 @@ const CodeBuilder ProgramBuilder("ProgramBuilder",
         std::make_tuple("value", valueProc),
 
         /* out of specification */
-        std::make_tuple("constructorInitializer", ctorInitProc),
         std::make_tuple("constructorInitializerList", ctorInitListProc),
         std::make_tuple(
             "xcodemlAccessToAnonRecordExpr", accessToAnonRecordExprProc),
@@ -748,6 +747,7 @@ const CodeBuilder ProgramBuilder("ProgramBuilder",
         std::make_tuple("clangDecl", clangDeclProc),
         std::make_tuple("clangTypeLoc", clangTypeLocProc),
         std::make_tuple("clangNestedNameSpecifier", clangNestedNameSpecProc),
+        std::make_tuple("clangConstructorInitializer", ctorInitProc),
 
         /* for CtoXcodeML */
         std::make_tuple("Decl_Record", NullProc),

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -588,16 +588,11 @@ getCtorInitName(xmlNodePtr node, const XcodeMl::Environment &env) {
     return makeTokenNode(*dataMember);
   }
   const auto base = getType(node);
-  if (base.hasValue()) {
-    const auto T = env[*base];
-    const auto classT = llvm::cast<XcodeMl::ClassType>(T.get());
-    const auto name = classT->name();
-    assert(name.hasValue());
-    return *name;
-  }
-
-  xmlDebugDumpNode(stderr, node, 0);
-  assert(false);
+  const auto T = env[base];
+  const auto classT = llvm::cast<XcodeMl::ClassType>(T.get());
+  const auto name = classT->name();
+  assert(name.hasValue());
+  return *name;
 }
 
 DEFINE_CB(ctorInitProc) {

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -587,7 +587,7 @@ getCtorInitName(xmlNodePtr node, const XcodeMl::Environment &env) {
   if (dataMember.hasValue()) {
     return makeTokenNode(*dataMember);
   }
-  const auto base = getPropOrNull(node, "type");
+  const auto base = getType(node);
   if (base.hasValue()) {
     const auto T = env[*base];
     const auto classT = llvm::cast<XcodeMl::ClassType>(T.get());

--- a/XcodeMLtoCXX/src/CodeBuilder.cpp
+++ b/XcodeMLtoCXX/src/CodeBuilder.cpp
@@ -598,7 +598,9 @@ getCtorInitName(xmlNodePtr node, const XcodeMl::Environment &env) {
 DEFINE_CB(ctorInitProc) {
   const auto member = getCtorInitName(node, src.typeTable);
   const auto expr = findFirst(node, "clangStmt[1]", src.ctxt);
-  assert(expr);
+  if (!expr) {
+    return member + wrapWithParen(makeVoidNode());
+  }
   const auto astClass = getPropOrNull(expr, "class");
   if (astClass.hasValue() && (*astClass == "CXXConstructExpr")) {
     return member + w.walk(expr, src);

--- a/tests/run/constructor.src.cpp
+++ b/tests/run/constructor.src.cpp
@@ -24,6 +24,12 @@ public:
   int bnum;
 };
 
+class ClassC : public ClassA {
+public:
+  ClassC() {
+  }
+};
+
 int
 main() {
   ClassA a1(10, 20);
@@ -34,4 +40,6 @@ main() {
   printf("%d\n", b1.bnum);
   ClassB b2(100);
   printf("%d\n", b2.bnum);
+  ClassC c1 = ClassC();
+  printf("%d\n", c1.num);
 }

--- a/tests/run/constructor.src.cpp
+++ b/tests/run/constructor.src.cpp
@@ -4,11 +4,17 @@ class ClassA {
 public:
   ClassA(int i, int j) : num(i * j) {
   }
+  ClassA(int i, int j, int k);
   int num;
 };
 
+ClassA::ClassA(int i, int j, int k) : num(i * j * k) {
+}
+
 int
 main() {
-  ClassA a(10, 20);
-  printf("%d\n", a.num);
+  ClassA a1(10, 20);
+  printf("%d\n", a1.num);
+  ClassA a2(10, 20, 30);
+  printf("%d\n", a2.num);
 }

--- a/tests/run/constructor.src.cpp
+++ b/tests/run/constructor.src.cpp
@@ -2,6 +2,8 @@
 
 class ClassA {
 public:
+  ClassA() : num(42) {
+  }
   ClassA(int i, int j) : num(i * j) {
   }
   ClassA(int i, int j, int k);
@@ -11,10 +13,25 @@ public:
 ClassA::ClassA(int i, int j, int k) : num(i * j * k) {
 }
 
+class ClassB : public ClassA {
+public:
+  ClassB() : ClassA(), bnum(100) {
+    bnum += num;
+  }
+  ClassB(int i) : ClassA(i, i), bnum(i) {
+    bnum += num;
+  }
+  int bnum;
+};
+
 int
 main() {
   ClassA a1(10, 20);
   printf("%d\n", a1.num);
   ClassA a2(10, 20, 30);
   printf("%d\n", a2.num);
+  ClassB b1 = ClassB();
+  printf("%d\n", b1.bnum);
+  ClassB b2(100);
+  printf("%d\n", b2.bnum);
 }

--- a/tests/run/constructor.src.cpp
+++ b/tests/run/constructor.src.cpp
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+class ClassA {
+public:
+  ClassA(int i, int j) : num(i * j) {
+  }
+  int num;
+};
+
+int
+main() {
+  ClassA a(10, 20);
+  printf("%d\n", a.num);
+}


### PR DESCRIPTION
逆変換がメンバー初期化子リストを無視するようになっていたので修正しました。