### PR TITLE
Don't use TemplateTypeParm::setSpelling 

### DIFF
--- a/CXXtoXML/src/TypeTableInfo.cpp
+++ b/CXXtoXML/src/TypeTableInfo.cpp
@@ -603,6 +603,8 @@ TypeTableInfo::registerType(QualType T, xmlNodePtr *retNode, xmlNodePtr) {
       xmlNewProp(Node,
           BAD_CAST "clang_index",
           BAD_CAST std::to_string(TTP->getIndex()).c_str());
+      const auto nameNode = makeNameNode(*this, TTP);
+      xmlAddChild(Node, nameNode);
       pushType(T, Node);
       break;
     }

--- a/CXXtoXML/src/XcodeMlNameElem.cpp
+++ b/CXXtoXML/src/XcodeMlNameElem.cpp
@@ -156,6 +156,18 @@ makeNameNode(TypeTableInfo &TTI, const DeclRefExpr *DRE) {
 }
 
 xmlNodePtr
+makeNameNode(TypeTableInfo &, const TemplateTypeParmType *TTP) {
+  assert(TTP);
+  const auto nameNode = xmlNewNode(nullptr, BAD_CAST "name");
+  const auto depth = TTP->getDepth();
+  const auto index = TTP->getIndex();
+  const auto name = "__xcodeml_template_type_" + std::to_string(depth) + "_"
+      + std::to_string(index);
+  xmlNodeAddContent(nameNode, BAD_CAST name.c_str());
+  return nameNode;
+}
+
+xmlNodePtr
 makeIdNodeForCXXMethodDecl(TypeTableInfo &TTI, const CXXMethodDecl *method) {
   auto idNode = xmlNewNode(nullptr, BAD_CAST "id");
   xmlNewProp(idNode,

--- a/CXXtoXML/src/XcodeMlNameElem.h
+++ b/CXXtoXML/src/XcodeMlNameElem.h
@@ -3,6 +3,7 @@
 
 xmlNodePtr makeNameNode(TypeTableInfo &, const clang::NamedDecl *);
 xmlNodePtr makeNameNode(TypeTableInfo &, const clang::DeclRefExpr *);
+xmlNodePtr makeNameNode(TypeTableInfo &, const clang::TemplateTypeParmType *);
 xmlNodePtr makeIdNodeForCXXMethodDecl(
     TypeTableInfo &, const clang::CXXMethodDecl *);
 xmlNodePtr makeIdNodeForFieldDecl(TypeTableInfo &, const clang::FieldDecl *);

--- a/XcodeMLtoCXX/src/ClangDeclHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangDeclHandler.cpp
@@ -382,14 +382,10 @@ DEFINE_DECLHANDLER(RecordProc) {
 }
 
 DEFINE_DECLHANDLER(TemplateTypeParmProc) {
-  const auto name = getQualifiedName(node, src);
-  const auto nameSpelling = name.toString(src.typeTable, src.nnsTable);
-
   const auto dtident = getType(node);
   auto T = src.typeTable.at(dtident);
   auto TTPT = llvm::cast<XcodeMl::TemplateTypeParm>(T.get());
-  assert(TTPT);
-  TTPT->setSpelling(nameSpelling);
+  const auto nameSpelling = TTPT->getSpelling().getValue();
 
   return makeTokenNode("typename") + nameSpelling;
 }

--- a/XcodeMLtoCXX/src/TypeAnalyzer.cpp
+++ b/XcodeMLtoCXX/src/TypeAnalyzer.cpp
@@ -198,7 +198,8 @@ DEFINE_TA(enumTypeProc) {
 
 DEFINE_TA(TemplateTypeParmTypeProc) {
   const auto dtident = getProp(node, "type");
-  map[dtident] = XcodeMl::makeTemplateTypeParm(dtident);
+  const auto name = getContent(findFirst(node, "name", ctxt));
+  map[dtident] = XcodeMl::makeTemplateTypeParm(dtident, makeTokenNode(name));
 }
 
 const std::vector<std::string> identicalFndDataTypeIdents = {

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -736,6 +736,11 @@ TemplateTypeParm::TemplateTypeParm(DataTypeIdent dtident)
     : Type(TypeKind::TemplateTypeParm, dtident) {
 }
 
+TemplateTypeParm::TemplateTypeParm(
+    const DataTypeIdent &dtident, const CodeFragment &name)
+    : Type(TypeKind::TemplateTypeParm, dtident), pSpelling(name) {
+}
+
 CodeFragment
 TemplateTypeParm::makeDeclaration(CodeFragment var, const Environment &) {
   assert(pSpelling.hasValue());

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -733,7 +733,7 @@ ClassType::ClassType(const ClassType &other)
 }
 
 TemplateTypeParm::TemplateTypeParm(DataTypeIdent dtident)
-    : Type(TypeKind::TemplateTypeParm, dtident) {
+    : Type(TypeKind::TemplateTypeParm, dtident), pSpelling() {
 }
 
 TemplateTypeParm::TemplateTypeParm(

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -953,11 +953,6 @@ makeCXXUnionType(const DataTypeIdent &ident,
 }
 
 TypeRef
-makeTemplateTypeParm(const DataTypeIdent &dtident) {
-  return std::make_shared<TemplateTypeParm>(dtident);
-}
-
-TypeRef
 makeTemplateTypeParm(const DataTypeIdent &dtident, const CodeFragment &name) {
   return std::make_shared<TemplateTypeParm>(dtident, name);
 }

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -958,6 +958,11 @@ makeTemplateTypeParm(const DataTypeIdent &dtident) {
 }
 
 TypeRef
+makeTemplateTypeParm(const DataTypeIdent &dtident, const CodeFragment &name) {
+  return std::make_shared<TemplateTypeParm>(dtident, name);
+}
+
+TypeRef
 makeOtherType(const DataTypeIdent &ident) {
   return std::make_shared<OtherType>(ident);
 }

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -732,10 +732,6 @@ ClassType::ClassType(const ClassType &other)
       classScopeSymbols(other.classScopeSymbols) {
 }
 
-TemplateTypeParm::TemplateTypeParm(DataTypeIdent dtident)
-    : Type(TypeKind::TemplateTypeParm, dtident), pSpelling() {
-}
-
 TemplateTypeParm::TemplateTypeParm(
     const DataTypeIdent &dtident, const CodeFragment &name)
     : Type(TypeKind::TemplateTypeParm, dtident), pSpelling(name) {

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -767,6 +767,15 @@ TemplateTypeParm::setSpelling(CodeFragment T) {
   pSpelling = T;
 }
 
+llvm::Optional<CodeFragment>
+TemplateTypeParm::getSpelling() const {
+  using MaybeName = llvm::Optional<CodeFragment>;
+  if (!pSpelling) {
+    return MaybeName();
+  }
+  return pSpelling;
+}
+
 OtherType::OtherType(const DataTypeIdent &ident)
     : Type(TypeKind::Other, ident) {
 }

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -504,6 +504,7 @@ TypeRef makeFunctionType(const DataTypeIdent &ident,
 TypeRef makeStructType(
     const DataTypeIdent &, const CodeFragment &, const Struct::MemberList &);
 TypeRef makeTemplateTypeParm(const DataTypeIdent &);
+TypeRef makeTemplateTypeParm(const DataTypeIdent &, const CodeFragment &);
 TypeRef makeVariadicFunctionType(const DataTypeIdent &ident,
     const DataTypeIdent &returnType,
     const std::vector<DataTypeIdent> &paramTypes);

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -435,7 +435,6 @@ private:
 
 class TemplateTypeParm : public Type {
 public:
-  TemplateTypeParm(DataTypeIdent);
   TemplateTypeParm(const DataTypeIdent &dtident, const CodeFragment &name);
   ~TemplateTypeParm() override = default;
   CodeFragment makeDeclaration(CodeFragment, const Environment &) override;

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -442,6 +442,7 @@ public:
   Type *clone() const override;
   static bool classof(const Type *);
   void setSpelling(CodeFragment);
+  llvm::Optional<CodeFragment> getSpelling() const;
 
 protected:
   TemplateTypeParm(const TemplateTypeParm &);

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -436,6 +436,7 @@ private:
 class TemplateTypeParm : public Type {
 public:
   TemplateTypeParm(DataTypeIdent);
+  TemplateTypeParm(const DataTypeIdent &dtident, const CodeFragment &name);
   ~TemplateTypeParm() override = default;
   CodeFragment makeDeclaration(CodeFragment, const Environment &) override;
   Type *clone() const override;

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -503,7 +503,6 @@ TypeRef makeFunctionType(const DataTypeIdent &ident,
     const std::vector<DataTypeIdent> &paramTypes);
 TypeRef makeStructType(
     const DataTypeIdent &, const CodeFragment &, const Struct::MemberList &);
-TypeRef makeTemplateTypeParm(const DataTypeIdent &);
 TypeRef makeTemplateTypeParm(const DataTypeIdent &, const CodeFragment &);
 TypeRef makeVariadicFunctionType(const DataTypeIdent &ident,
     const DataTypeIdent &returnType,


### PR DESCRIPTION
There are two types of `clang::TemplateTypeParmType` objects; canonical and non-canonical. A non-canonical `TemplateTypeParmType` has a pointer to a `clang::TeplateTypeParmDecl`. A canonical `TemplateTypeParmType` does not have such a pointer, but it has two `unsigned` numbers; `index` and `depth`.

    // include/clang/AST/Type.h
    class TemplateTypeParmType : public Type, public llvm::FoldingSetNode {
      // Helper data collector for canonical types.
      struct CanonicalTTPTInfo {
        unsigned Depth : 15;
        unsigned ParameterPack : 1;
        unsigned Index : 16;
      };

      union {
        // Info for the canonical type.
        CanonicalTTPTInfo CanTTPTInfo;
        // Info for the non-canonical type.
        TemplateTypeParmDecl *TTPDecl;
      };

We can retrieve canonical `TemplateTypeParmType`s from non-canonical ones, but the reverse is not true.

We decided not to emit template type parameter names to `xcodemlTypeTable/TemplateTypeParmType/name` as written because canonical `TemplateTypeParmType`s have no information about their names. Instead, we rename them using their indices and depths.