### PR TITLE
Fix typo in Array::makeDeclaration (XcodeMlType.cpp)

### DIFF
--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -387,8 +387,6 @@ Array::makeDeclaration(CodeFragment var, const Environment &env) {
       ? makeTokenNode(std::to_string(size.size))
       : makeTokenNode("*");
   const CodeFragment declarator = makeTokenNode("[")
-      + (isConst() ? makeTokenNode("const") : makeVoidNode())
-      + (isVolatile() ? makeTokenNode("volatile") : makeVoidNode())
       + size_expression + makeTokenNode("]");
   return makeDecl(elementType, var + declarator, env);
 }
@@ -408,18 +406,6 @@ Array::classof(const Type *T) {
 
 Array::Array(const Array &other)
     : Type(other), element(other.element), size(other.size) {
-}
-
-CodeFragment
-Array::addConstQualifier(CodeFragment var) const {
-  // add cv-qualifiers in Array::makeDeclaration, not here
-  return var;
-}
-
-CodeFragment
-Array::addVolatileQualifier(CodeFragment var) const {
-  // add cv-qualifiers in Array::makeDeclaration, not here
-  return var;
 }
 
 TypeRef

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -387,6 +387,8 @@ Array::makeDeclaration(CodeFragment var, const Environment &env) {
       ? makeTokenNode(std::to_string(size.size))
       : makeTokenNode("*");
   const CodeFragment declarator = makeTokenNode("[")
+      + (isConst() ? makeTokenNode("const") : makeVoidNode())
+      + (isVolatile() ? makeTokenNode("volatile") : makeVoidNode())
       + size_expression + makeTokenNode("]");
   return makeDecl(elementType, var + declarator, env);
 }
@@ -406,6 +408,18 @@ Array::classof(const Type *T) {
 
 Array::Array(const Array &other)
     : Type(other), element(other.element), size(other.size) {
+}
+
+CodeFragment
+Array::addConstQualifier(CodeFragment var) const {
+  // add cv-qualifiers in Array::makeDeclaration, not here
+  return var;
+}
+
+CodeFragment
+Array::addVolatileQualifier(CodeFragment var) const {
+  // add cv-qualifiers in Array::makeDeclaration, not here
+  return var;
 }
 
 TypeRef

--- a/XcodeMLtoCXX/src/XcodeMlType.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlType.cpp
@@ -388,7 +388,7 @@ Array::makeDeclaration(CodeFragment var, const Environment &env) {
       : makeTokenNode("*");
   const CodeFragment declarator = makeTokenNode("[")
       + (isConst() ? makeTokenNode("const") : makeVoidNode())
-      + (isConst() ? makeTokenNode("volatile") : makeVoidNode())
+      + (isVolatile() ? makeTokenNode("volatile") : makeVoidNode())
       + size_expression + makeTokenNode("]");
   return makeDecl(elementType, var + declarator, env);
 }

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -87,7 +87,7 @@ public:
    * given
    * string (`x` -> `const x`). Some derived classes use different ways. For
    * example,
-   * `XcodeMl::Function::addConstQualifier` returns a string identical to the
+   * `XcodeMl::Array::addConstQualifier` returns a string identical to the
    * parameter.
    */
   virtual CodeFragment addConstQualifier(CodeFragment) const;
@@ -100,7 +100,7 @@ public:
    * the
    * given string (`x` -> `volatile x`). Some derived classes use different
    * ways.
-   * For example, `XcodeMl::Function::addVolatileQualifier` returns a string
+   * For example, `XcodeMl::Array::addVolatileQualifier` returns a string
    * identical to the parameter.
    */
   virtual CodeFragment addVolatileQualifier(CodeFragment) const;

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -287,6 +287,8 @@ public:
   CodeFragment makeDeclaration(CodeFragment, const Environment &) override;
   ~Array() override;
   Type *clone() const override;
+  CodeFragment addConstQualifier(CodeFragment) const override;
+  CodeFragment addVolatileQualifier(CodeFragment) const override;
   static bool classof(const Type *);
   /*! Returns the element type as `XcodeMl::TypeRef`. */
   TypeRef getElemType(const Environment &) const;

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -87,7 +87,7 @@ public:
    * given
    * string (`x` -> `const x`). Some derived classes use different ways. For
    * example,
-   * `XcodeMl::Array::addConstQualifier` returns a string identical to the
+   * `XcodeMl::Function::addConstQualifier` returns a string identical to the
    * parameter.
    */
   virtual CodeFragment addConstQualifier(CodeFragment) const;
@@ -100,7 +100,7 @@ public:
    * the
    * given string (`x` -> `volatile x`). Some derived classes use different
    * ways.
-   * For example, `XcodeMl::Array::addVolatileQualifier` returns a string
+   * For example, `XcodeMl::Function::addVolatileQualifier` returns a string
    * identical to the parameter.
    */
   virtual CodeFragment addVolatileQualifier(CodeFragment) const;

--- a/XcodeMLtoCXX/src/XcodeMlType.h
+++ b/XcodeMLtoCXX/src/XcodeMlType.h
@@ -287,8 +287,6 @@ public:
   CodeFragment makeDeclaration(CodeFragment, const Environment &) override;
   ~Array() override;
   Type *clone() const override;
-  CodeFragment addConstQualifier(CodeFragment) const override;
-  CodeFragment addVolatileQualifier(CodeFragment) const override;
   static bool classof(const Type *);
   /*! Returns the element type as `XcodeMl::TypeRef`. */
   TypeRef getElemType(const Environment &) const;

--- a/tests/run/array.src.cpp
+++ b/tests/run/array.src.cpp
@@ -18,4 +18,9 @@ main() {
       printf("%d\n", i);
     }
   }
+
+  const int array10_ci[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  for (int i = 0; i < 10; ++i) {
+    printf("%d\n", array10_ci[i]);
+  }
 }

--- a/tests/run/array_to_cv_qual_type.src.cpp
+++ b/tests/run/array_to_cv_qual_type.src.cpp
@@ -1,0 +1,50 @@
+#include <stdio.h>
+
+int g_a4i[4];
+const int g_a4ci[4] = {100, 200, 300, 400};
+volatile int g_a4vi[4];
+const volatile int g_a4cvi[4] = {1, 2, 3, 4};
+
+void
+func_pi(int *pi) {
+  for (int k = 0; k < 4; ++k) {
+    printf("int *: %d\n", pi[k]);
+  }
+}
+
+void
+func_pci(const int *pci) {
+  for (int k = 0; k < 4; ++k) {
+    printf("const int *: %d\n", pci[k]);
+  }
+}
+
+void
+func_pvi(volatile int *pvi) {
+  for (int k = 0; k < 4; ++k) {
+    printf("volatile int *: %d\n", pvi[k]);
+  }
+}
+
+void
+func_pcvi(const volatile int *pcvi) {
+  for (int k = 0; k < 4; ++k) {
+    printf("const volatile int *: %d\n", pcvi[k]);
+  }
+}
+
+int
+main() {
+  int b_a4i[4] = {2, 4, 6, 8};
+  const int b_a4ci[4] = {};
+  volatile int b_a4vi[4] = {1, 10, 100, 1000};
+  const volatile int b_a4cvi[4] = {3, 6, 9, 12};
+  func_pi(b_a4i);
+  func_pci(b_a4ci);
+  func_pvi(b_a4vi);
+  func_pcvi(b_a4cvi);
+  func_pi(g_a4i);
+  func_pci(g_a4ci);
+  func_pvi(g_a4vi);
+  func_pcvi(g_a4cvi);
+}


### PR DESCRIPTION
```diff
@@ -388,7 +388,7 @@ Array::makeDeclaration(CodeFragment var, const Environment &env) {
       : makeTokenNode("*");
   const CodeFragment declarator = makeTokenNode("[")
       + (isConst() ? makeTokenNode("const") : makeVoidNode())
-      + (isConst() ? makeTokenNode("volatile") : makeVoidNode())
+      + (isVolatile() ? makeTokenNode("volatile") : makeVoidNode())
       + size_expression + makeTokenNode("]");
   return makeDecl(elementType, var + declarator, env);
 }
```