### PR TITLE
support bit fields (including unnamed bit fields)

### DIFF
--- a/XcodeMLtoCXX/src/ClangDeclHandler.cpp
+++ b/XcodeMLtoCXX/src/ClangDeclHandler.cpp
@@ -324,13 +324,20 @@ DEFINE_DECLHANDLER(EnumConstantProc) {
 }
 
 DEFINE_DECLHANDLER(FieldDeclProc) {
-  const auto nameNode = findFirst(node, "name", src.ctxt);
-  const auto name = getUnqualIdFromNameNode(nameNode)->toString(src.typeTable);
-
   const auto dtident = getType(node);
   const auto T = src.typeTable.at(dtident);
+  auto name = CXXCodeGen::makeVoidNode();
+  auto bits= CXXCodeGen::makeVoidNode();
 
-  return makeDecl(T, name, src.typeTable);
+  if (isTrueProp(node, "is_bit_field", false)) {
+    const auto bitsNode = findFirst(node, "clangStmt", src.ctxt);
+    bits = makeTokenNode(":") + w.walk(bitsNode, src);
+  }
+  if (!isTrueProp(node, "is_unnamed_bit_field", false)) {
+    const auto nameNode = findFirst(node, "name", src.ctxt);
+    name = getUnqualIdFromNameNode(nameNode)->toString(src.typeTable);
+  }
+  return makeDecl(T, name, src.typeTable) + bits;
 }
 
 DEFINE_DECLHANDLER(FriendDeclProc) {

--- a/XcodeMLtoCXX/src/XMLWalker.h
+++ b/XcodeMLtoCXX/src/XMLWalker.h
@@ -179,7 +179,7 @@ public:
       try {
         (iter->second)(*this, node, args...);
       } catch (const std::exception &e) {
-        std::cerr << "In " << name << std::endl << e.what() << std::endl;
+        std::cerr << "In " << name << ": walk(" << elemName << ")" << std::endl << e.what() << std::endl;
         xmlDebugDumpNode(stderr, node, 0);
         abort();
       }

--- a/XcodeMLtoCXX/src/XcodeMlName.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlName.cpp
@@ -160,4 +160,23 @@ DtorName::classof(const UnqualId *id) {
   return id->getKind() == UnqualIdKind::Dtor;
 }
 
+
+UnnamedId::UnnamedId() : UnqualId(UnqualIdKind::Unnamed) {
+}
+
+UnqualId *
+UnnamedId::clone() const {
+  return new UnnamedId();
+}
+
+CodeFragment
+UnnamedId::toString(const TypeTable &env) const {
+  return makeTokenNode("");
+}
+
+bool
+UnnamedId::classof(const UnqualId *id) {
+  return id->getKind() == UnqualIdKind::Unnamed;
+}
+
 } // namespace XcodeMl

--- a/XcodeMLtoCXX/src/XcodeMlName.h
+++ b/XcodeMLtoCXX/src/XcodeMlName.h
@@ -22,6 +22,8 @@ enum class UnqualIdKind {
   Ctor,
   /*! Destructor name */
   Dtor,
+  /*! unnamed (bit field) */
+  Unnamed,
 };
 
 /*!
@@ -141,6 +143,19 @@ protected:
 
 private:
   DataTypeIdent dtident;
+};
+
+/*! \brief Represents "unnamed" id (such as unnamed bit field) . */
+class UnnamedId : public UnqualId {
+public:
+  UnnamedId();
+  ~UnnamedId() override = default;
+  UnqualId *clone() const override;
+  CodeFragment toString(const TypeTable &) const override;
+  static bool classof(const UnqualId *);
+
+protected:
+  UnnamedId(const UnnamedId &) = default;
 };
 
 } // namespace XcodeMl

--- a/XcodeMLtoCXX/src/XcodeMlUtil.cpp
+++ b/XcodeMLtoCXX/src/XcodeMlUtil.cpp
@@ -58,7 +58,8 @@ getUnqualIdFromIdNode(xmlNodePtr idNode, xmlXPathContextPtr ctxt) {
   }
   xmlNodePtr nameNode = findFirst(idNode, "name", ctxt);
   if (!nameNode) {
-    throw std::domain_error("name node not found");
+    return std::make_shared<XcodeMl::UnnamedId>();
+    //throw std::domain_error("name node not found");
   }
   return getUnqualIdFromNameNode(nameNode);
 }


### PR DESCRIPTION
ビットフィールドをサポートしました。
- ビットフィールドのビット長は式となりうるため TypeTable には持たない設計になってしまっているので、
  FieldDecl として出力する歳に is_bit_field, is_unnamed_bit_field の属性（これは PR #305 で追加済み）を見て適切に処理するようにした
- 特に「無名ビットフィールド」をサポートするために、
  XcodeMlType の ClassType が保持している classScopeSymbols の UnqualId 部に UnnamedId という種別を追加 (toString したら "" が返る)

の二点が主な変更点です。

また、もともと XMLWalker walk() で例外をキャッチしていたところで落ちていたので、
そこのデバッグ用のログの生成を少しだけ丁寧にしました。